### PR TITLE
Fix documentation, add: git submodule update --recursive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ If you have `git` installed, you can use (on Mac/Unix):
 % cd ~/git
 % git clone https://github.com/cuthbertLab/music21j.git
 % cd music21j
+% git submodule init
+% git submodule update
+% git pull
+% git submodule update --recursive
 % npm install
 ```
 


### PR DESCRIPTION
Hi! This PR is about the documentation that needed an update to show that you need to download the submodules to get music21j working correctly. I got it running on windows 8.1 with the following git commands, maybe it can be done in less steps.

git clone git://url...
cd music21j
git submodule init
git submodule update
git pull 
git submodule update --recursive.

Best regards.
Cristian Bañuelos
