### PR TITLE
Fix package entry-point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "music21j",
   "version": "0.9.43",
   "description": "A toolkit for computer-aided musicology, Javascript version",
-  "main": "src/music21_modules.js",
+  "main": "releases/music21.debug.js",
   "files": [
     ".editorconfig",
     ".eslintignore",
@@ -93,6 +93,5 @@
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/cuthbertLab/music21j/issues"
-  },
-  "type": "module"
+  }
 }


### PR DESCRIPTION
This allows people installing the package via `npm` and developing a client application with `webpack` to simply import the library as:

```js
import * as music21 from "music21j"
```

This partially closes #58 (the other issue might as well be tracked on a separate issue).

Furthermore, I think the directive `module` on the `package.json` file is not really needed (the bundled entrypoint can be treated as a commonJS module, users are not expected to consume source files in `src/` without webpack processing). Also, `grunt` would complain that `Gruntfile.js` is not a ES6 module, if such directive is kept (the other alternative would be to rename `Gruntfile.js` → `Gruntfile.cjs`).

PS: I'm working on a possibly better way to handle the builds instead of committing them along with the source code here: [mttbernardini/music21j@webpack](https://github.com/mttbernardini/music21j/tree/webpack)