### PR TITLE
Chord: sort pitches by diatonicNoteNum as well as ps

### DIFF
--- a/src/music21/chord.ts
+++ b/src/music21/chord.ts
@@ -317,7 +317,13 @@ export class Chord extends note.NotRest {
     }
 
     sortPitches() {
-        this._notes.sort((a, b) => a.pitch.ps - b.pitch.ps);
+        this._notes.sort((a, b) => {
+            let diff: number = a.pitch.ps - b.pitch.ps;
+            if (diff === 0) {
+                diff = a.pitch.diatonicNoteNum - b.pitch.diatonicNoteNum;
+            }
+            return diff;
+        });
     }
 
     // TODO: add remove

--- a/src/music21/chord.ts
+++ b/src/music21/chord.ts
@@ -318,9 +318,9 @@ export class Chord extends note.NotRest {
 
     sortPitches() {
         this._notes.sort((a, b) => {
-            let diff: number = a.pitch.ps - b.pitch.ps;
+            let diff: number = a.pitch.diatonicNoteNum - b.pitch.diatonicNoteNum;
             if (diff === 0) {
-                diff = a.pitch.diatonicNoteNum - b.pitch.diatonicNoteNum;
+                diff = a.pitch.ps - b.pitch.ps;
             }
             return diff;
         });

--- a/tests/moduleTests/chord.js
+++ b/tests/moduleTests/chord.js
@@ -31,4 +31,18 @@ export default function tests() {
         assert.equal(pitches[2].nameWithOctave, 'C5');
 
     });
+
+    test('music21.chord.Chord sortPitches', assert => {
+        // Same ps, but diatonicNoteNum is out of order.
+        let c = new music21.chord.Chord(['Bb4', 'A#4']);
+        let [note1, note2] = c.notes;
+        assert.equal(note1.pitch.nameWithOctave, 'A#4');
+        assert.equal(note2.pitch.nameWithOctave, 'B-4');
+
+        // Same diatonicNoteNum, but ps is out of order.
+        c = new music21.chord.Chord(['B4', 'Bb4']);
+        [note1, note2] = c.notes;
+        assert.equal(note1.pitch.nameWithOctave, 'B-4');
+        assert.equal(note2.pitch.nameWithOctave, 'B4');
+    });
 }


### PR DESCRIPTION
Vexflow sorts `StaveNote` keys based on pitch height at instantiation. When adding a modifier such as an accidental, Vexflow expects an index that corresponds to the sorted order, _not_ the insertion order. (See https://github.com/0xfe/vexflow/issues/104).

Sorting by `diatonicNoteNum` ensures that enharmonic notes are in the correct order, and receive the right modifiers.