### PR TITLE
Impose music21p search restriction for Roman numeral strings

### DIFF
--- a/src/music21/roman.ts
+++ b/src/music21/roman.ts
@@ -484,9 +484,9 @@ export class RomanNumeral extends harmony.Harmony {
     _parseRNAloneAmidstAug6(workingFigure, useScale) {
         let romanNumeralAlone = '';
         const _romanNumeralAloneRegex = new RegExp(
-            '(IV|I{1,3}|VI{0,2}|iv|i{1,3}|vi{0,2}|N)'
+            '^(IV|I{1,3}|VI{0,2}|iv|i{1,3}|vi{0,2}|N)'
         );
-        const _augmentedSixthRegex = new RegExp('(It|Ger|Fr|Sw)');
+        const _augmentedSixthRegex = new RegExp('^(It|Ger|Fr|Sw)');
         const rm = _romanNumeralAloneRegex.exec(workingFigure);
         const a6match = _augmentedSixthRegex.exec(workingFigure);
         if (rm === null && a6match === null) {

--- a/tests/moduleTests/roman.js
+++ b/tests/moduleTests/roman.js
@@ -114,6 +114,17 @@ export default function tests() {
         assert.equal(rn1.third.name, 'E-', 'test third of Cad64');
     });
 
+    test('music21.roman.RomanNumeral - invalid arguments', assert => {
+        // Invalid first char should throw an exception,
+        // even if the chars that follow are valid.
+        assert.throws(() => {
+            return new music21.roman.RomanNumeral('CI');
+        }, /No roman numeral found in CI/);
+        assert.throws(() => {
+            return new music21.roman.RomanNumeral('CIt');
+        }, /No roman numeral found in CIt/);
+    });
+
     test('music21.roman.RomanNumeral - inversions', assert => {
         const t1 = 'IV6';
         let rn1;


### PR DESCRIPTION
In music21p, the `romanNumeralAloneRegex` and `augmentedSixthRegex` regex objects use the `match` method, which restricts the search to the front of the string (see https://docs.python.org/3/library/re.html#search-vs-match). This PR imposes the same restriction on the analogous objects in JS.



