### PR TITLE
Add useVexflowAutobeam to renderOptions

### DIFF
--- a/src/music21/meter.ts
+++ b/src/music21/meter.ts
@@ -213,6 +213,12 @@ export class TimeSignature extends base.Music21Object {
             if (!beams) {
                 return;
             }
+
+            if (el.duration.quarterLength >= this.beatDuration.quarterLength) {
+                beamsList[i] = undefined;
+                return;
+            }
+
             const beamNumber = depth + 1;
             if (!(beams.getNumbers().includes(beamNumber))) {
                 return;
@@ -250,9 +256,11 @@ export class TimeSignature extends base.Music21Object {
                     beamType = 'partial-right';
                 }
             } else if (isLast) {
-                beamType = 'start';
+                beamType = 'stop';
                 if (beamPrevious === undefined || !beamPrevious.getNumbers().includes(beamNumber)) {
                     beamType = 'partial-left';
+                } else if (beamPrevious && beamPrevious.getTypeByNumber(beamNumber) === 'stop') {
+                    beamsList[i] = undefined;
                 }
             } else if (beamPrevious === undefined || !beamPrevious.getNumbers().includes(beamNumber)) {
                 if (beamNumber === 1 && beamNext === undefined) {
@@ -289,11 +297,11 @@ export class TimeSignature extends base.Music21Object {
             beams.setByNumber(beamNumber, beamType);
         };
 
+        const elList = Array.from(srcStream);
         for (let depth = 0; depth < beam.beamableDurationTypes.length; depth++) {
-            let i = 0;
-            for (const el of srcStream) {
+            for (let i = 0; i < elList.length; i++) {
+                const el = elList[i];
                 fixBeamsOneElementDepth(i, el, depth);
-                i += 1;
             }
         }
 

--- a/src/music21/renderOptions.ts
+++ b/src/music21/renderOptions.ts
@@ -77,6 +77,8 @@ export class RenderOptions {
         // resize
     };
 
+    useVexflowAutobeam: boolean = true;
+
     startNewSystem: boolean = false;
     // noinspection JSUnusedGlobalSymbols
     startNewPage: boolean = false;

--- a/src/music21/vfShow.ts
+++ b/src/music21/vfShow.ts
@@ -554,6 +554,7 @@ export class Renderer {
         const allTickables = stack.allTickables();
         const vf_voices = stack.voices;
         const measuresOrVoices = stack.streams;
+        const useVexflowAutobeam = measuresOrVoices[0].renderOptions.useVexflowAutobeam;
         if (autoBeam === undefined) {
             autoBeam = measuresOrVoices[0].autoBeam;
         }
@@ -583,7 +584,7 @@ export class Renderer {
         }
         formatter.formatToStave(allTickables, stave);
 
-        if (autoBeam) {
+        if (autoBeam && useVexflowAutobeam) {
             for (let i = 0; i < vf_voices.length; i++) {
                 // find beam groups -- n.b. this wipes out stemDirection. worth it usually...
                 const vf_voice = vf_voices[i];
@@ -621,7 +622,7 @@ export class Renderer {
                         activeBeamGroupNotes.push(n.activeVexflowNote);
                     }
                     if (eighthNoteBeam.type === 'stop') {
-                        const vfBeam = new Vex.Flow.Beam(activeBeamGroupNotes);
+                        const vfBeam = new Vex.Flow.Beam(activeBeamGroupNotes, true);
                         this.beamGroups.push(vfBeam);
                         activeBeamGroupNotes = [];
                     }

--- a/tests/moduleTests/beam.js
+++ b/tests/moduleTests/beam.js
@@ -5,22 +5,31 @@ const { test } = QUnit;
 
 
 export default function tests() {
-    test('music21.beam.Beams', assert => {
+    test('music21.beam.Beams setAll', assert => {
         const a = new music21.beam.Beams();
         a.fill('16th');
         a.setAll('start');
+
         assert.equal(a.getTypes()[0], 'start');
         assert.equal(a.getTypes()[1], 'start');
+    });
 
+    test('music21.beam.Beams setByNumber', assert => {
         const b = new music21.beam.Beams();
         b.fill('16th');
         b.setAll('start');
+
         b.setByNumber(1, 'continue');
         assert.equal(b.beamsList[0].type, 'continue');
+        assert.equal(b.getTypeByNumber(1), 'continue');
+
         b.setByNumber(2, 'stop');
         assert.equal(b.beamsList[1].type, 'stop');
+        assert.equal(b.getTypeByNumber(2), 'stop');
+
         b.setByNumber(2, 'partial-right');
         assert.equal(b.beamsList[1].type, 'partial');
+        assert.equal(b.getTypeByNumber(2), 'partial-right');
         assert.equal(b.beamsList[1].direction, 'right');
     });
 }

--- a/tests/moduleTests/meter.js
+++ b/tests/moduleTests/meter.js
@@ -28,6 +28,62 @@ export default function tests() {
 
     });
 
+    test('music21.meter.TimeSignature getBeams', assert => {
+        const m = new music21.stream.Measure();
+        m.append(new music21.note.Note('C', 1.5));
+        m.append(new music21.note.Note('C', 0.5));
+        m.append(new music21.note.Note('C', 0.5));
+        m.append(new music21.note.Note('C', 0.5));
+
+        const ts = new music21.meter.TimeSignature('3/4');
+        const beamsList = ts.getBeams(m);
+
+        assert.strictEqual(typeof beamsList[0], 'undefined');
+        assert.strictEqual(typeof beamsList[1], 'undefined');
+        assert.ok(beamsList[2] instanceof music21.beam.Beams);
+        assert.ok(beamsList[3] instanceof music21.beam.Beams);
+
+        assert.strictEqual(beamsList[2].beamsList[0].type, 'start');
+        assert.strictEqual(beamsList[3].beamsList[0].type, 'stop');
+    });
+
+    test('music21.meter.TimeSignature getBeams 3/8', assert => {
+        const m = new music21.stream.Measure();
+        m.append(new music21.note.Note('C', 0.5));
+        m.append(new music21.note.Note('C', 0.75));
+        m.append(new music21.note.Note('C', 0.25));
+
+        const ts = new music21.meter.TimeSignature('3/8');
+        const beamsList = ts.getBeams(m);
+
+        for (const beam of beamsList) {
+            assert.strictEqual(
+                typeof beam,
+                'undefined',
+                '8th notes should not get beams when the 8th note gets the beat'
+            );
+        }
+    });
+
+    test('music21.meter.TimeSignature getBeams incomplete measure', assert => {
+        const m = new music21.stream.Measure();
+
+        // incomplete measure in 2/4
+        m.append(new music21.note.Note('C', 0.5));
+        m.append(new music21.note.Note('C', 0.5));
+        m.append(new music21.note.Note('C', 0.5));
+
+        const ts = new music21.meter.TimeSignature('2/4');
+        const beamsList = ts.getBeams(m);
+
+        assert.ok(beamsList[0] instanceof music21.beam.Beams);
+        assert.ok(beamsList[1] instanceof music21.beam.Beams);
+        assert.strictEqual(typeof beamsList[2], 'undefined');
+
+        assert.strictEqual(beamsList[0].beamsList[0].type, 'start');
+        assert.strictEqual(beamsList[1].beamsList[0].type, 'stop');
+    });
+
     test('music21.meter.TimeSignature compound', assert => {
         const m = new music21.meter.TimeSignature('6/8');
 


### PR DESCRIPTION
With autobeam enabled, `Stream.makeBeams()` generates `Beams` objects for the stream, but these beams are NOT used when the stream is rendered to the DOM: Vexflow's `Beam.applyAndGetBeams()` is used instead. VexFlow's autobeam system is great, but suffers from issues as late as 2020 (https://github.com/0xfe/vexflow/commit/253698ea503a684e019903ff7da0d9a7036d3565).

When `renderOptions.useVexflowAutobeam` is disabled, we avoid Vexflow and the stream is instead rendered with its own beam information.




