### PR TITLE
Autobeam cleanup

### DIFF
--- a/src/music21/vfShow.ts
+++ b/src/music21/vfShow.ts
@@ -554,7 +554,7 @@ export class Renderer {
         const allTickables = stack.allTickables();
         const vf_voices = stack.voices;
         const measuresOrVoices = stack.streams;
-        const useVexflowAutobeam = measuresOrVoices[0].renderOptions.useVexflowAutobeam;
+        const useVexflowAutobeam = this.stream.renderOptions.useVexflowAutobeam;
         if (autoBeam === undefined) {
             autoBeam = measuresOrVoices[0].autoBeam;
         }
@@ -584,9 +584,9 @@ export class Renderer {
         }
         formatter.formatToStave(allTickables, stave);
 
+        // VexFlow and native autobeam both wipe out stemDirection. worth it usually...
         if (autoBeam && useVexflowAutobeam) {
             for (let i = 0; i < vf_voices.length; i++) {
-                // find beam groups -- n.b. this wipes out stemDirection. worth it usually...
                 const vf_voice = vf_voices[i];
                 const associatedStream = stack.voiceToStreamMapping.get(vf_voice);
                 let beatGroups;

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -30,8 +30,18 @@ export default function tests() {
         renderer.render();
         assert.equal(renderer.beamGroups.length, 3);
 
+        s.autoBeam = true;
+
+        // VexFlow autobeam sets the correct number of beams
+        s.renderOptions.useVexflowAutobeam = true;
         renderer = new music21.vfShow.Renderer(s, svg);
-        s.autoBeam = true;  // sets the correct number of beams
+        renderer.render();
+        assert.equal(renderer.beamGroups.length, 2);
+
+        // Native autobeam also sets the correct number of beams
+        s.renderOptions.useVexflowAutobeam = false;
+        s.makeBeams({ inPlace: true });
+        renderer = new music21.vfShow.Renderer(s, svg);
         renderer.render();
         assert.equal(renderer.beamGroups.length, 2);
     });


### PR DESCRIPTION
Follow-on work related to #75. In `vfShow`, retrieve `useVexflowAutobeam` from the top-level stream.