### PR TITLE
Add site when setting elements via Stream.elements

### DIFF
--- a/src/music21/stream.ts
+++ b/src/music21/stream.ts
@@ -649,6 +649,7 @@ export class Stream extends base.Music21Object {
                 // append
                 this._elements.push(thisEl);
                 this.setElementOffset(thisEl, highestOffsetSoFar);
+                thisEl.sites.add(this);
                 if (thisEl.duration === undefined) {
                     console.error('No duration for ', thisEl, ' in ', this);
                 }

--- a/src/music21/vfShow.ts
+++ b/src/music21/vfShow.ts
@@ -439,7 +439,7 @@ export class Renderer {
      * @param {Stream} p - a Part or similar object
      */
     prepareTies(p: stream.Stream) {
-        const pf = <note.GeneralNote[]> Array.from(p.recurse().notesAndRests);
+        const pf = <note.GeneralNote[]> Array.from(p.flat.notesAndRests);
         // console.log('newSystemsAt', this.systemBreakOffsets);
         for (let i = 0; i < pf.length - 1; i++) {
             const thisNote = pf[i];
@@ -452,8 +452,8 @@ export class Renderer {
             for (let sbI = 0; sbI < this.systemBreakOffsets.length; sbI++) {
                 const thisSystemBreak = this.systemBreakOffsets[sbI];
                 if (
-                    thisNote.getOffsetInHierarchy(p) < thisSystemBreak
-                    && nextNote.getOffsetInHierarchy(p) >= thisSystemBreak
+                    thisNote.offset < thisSystemBreak
+                    && nextNote.offset >= thisSystemBreak
                 ) {
                     onSameSystem = false;
                     break;

--- a/tests/moduleTests/stream.js
+++ b/tests/moduleTests/stream.js
@@ -130,6 +130,15 @@ export default function tests() {
         t.elements = s;
         assert.deepEqual(t.get(1), d, 't[1] is d');
         assert.equal(t.get(1).offset, 10, 'd offset retained');
+
+        const p1 = new music21.stream.Part();
+        const m = new music21.stream.Measure();
+        const n = new music21.note.Note('C');
+        m.append(n);
+        p1.append(m);
+        const p2 = new music21.stream.Part();
+        p2.elements = p1;
+        assert.equal(n.getOffsetInHierarchy(p2), 0, 'p2 is in the site hierarchy of n');
     });
 
     test('music21.stream.Stream.duration', assert => {


### PR DESCRIPTION
Also prefer `offset` over `getOffsetInHierarchy` for speed.