### PR TITLE
Specify data type when jQuery parses XML fetched from a URL

### DIFF
--- a/src/musicxml/xmlToM21.ts
+++ b/src/musicxml/xmlToM21.ts
@@ -66,8 +66,9 @@ export class ScoreParser {
 
     scoreFromUrl(url) {
         this.xmlUrl = url;
+        const dataType = 'xml';
         // noinspection JSUnusedLocalSymbols
-        return $.get(url, {}, (xmlDoc, textStatus) => this.scoreFromDOMTree(xmlDoc));
+        return $.get(url, {}, (xmlDoc, textStatus) => this.scoreFromDOMTree(xmlDoc), dataType);
     }
 
     scoreFromText(xmlText) {


### PR DESCRIPTION
Fixes #97 

Previously, jQuery made its "Intelligent Guess" of the data type, so you might get back a document object or a string, but the next method called is `scoreFromDOMTree()`, so we need to have a document object. In the linked issue I used the same example from the demo but called raw.githubusercontent.com, upon which jQuery gave me a string.

[jQuery docs](https://api.jquery.com/jQuery.get/)