### PR TITLE
Type `.notes()` as providing a NotRest iterator

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -389,9 +389,9 @@ export class Stream extends base.Music21Object {
         return newSt as this;
     }
 
-    get notes(): iterator.StreamIterator<note.GeneralNote> {
+    get notes(): iterator.StreamIterator<note.NotRest> {
         return this.getElementsByClass(['Note', 'Chord']) as
-            iterator.StreamIterator<note.GeneralNote>;
+            iterator.StreamIterator<note.NotRest>;
     }
 
     get notesAndRests(): iterator.StreamIterator<note.GeneralNote> {


### PR DESCRIPTION
This could be tightened up to avoid so much casting to `.notes() as music21.note.Note[]` or `NotRest[]`.

Noticed when working on #110, because I didn't have access to `.stemDirection` without specifying a better type.