### PR TITLE
Fix package entry point and publish type declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 node_modules/
 node_modules/grunt/package.json
 
-build/*.js
-build/*.map
+build/
 
 tests/music21.tests.js
 tests/music21.tests.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,18 @@
-#node
+# node
 node_modules/
 node_modules/grunt/package.json
 
+# Build is not committed, just releases/
 build/
 
+# Built tests
 tests/music21.tests.js
 tests/music21.tests.js.map
 
+# Python files
+__pycache__
 *.py[cod]
+
 .buildpath
 
 # emacs
@@ -17,9 +22,11 @@ tests/music21.tests.js.map
 # vim
 *.swp
 
-#Eclipse
+# Eclipse
 /.settings
 .settings
+
+# IDEA
 .project
 .pydevproject
 
@@ -42,7 +49,6 @@ develop-eggs
 .installed.cfg
 lib
 lib64
-__pycache__
 
 # Installer logs
 pip-log.txt
@@ -69,8 +75,3 @@ node_modules/grunt-contrib-uglify/package.json
 .idea/music21j.iml
 .idea/vcs.xml
 .idea/workspace.xml
-
-
-# Built tests
-tests/music21.tests.js
-tests/music21.tests.js.map

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,9 +28,6 @@ module.exports = grunt => {
     // const TARGET_MIN = path.join(BUILD_DIR, 'music21.min.js');
 
     const SOURCES = [
-        'src/music21_modules.js',
-        'src/music21/*.js',
-        'src/music21/*/*.js',
         'src/music21/*.ts',
         'src/music21/*/*.ts',
     ];
@@ -171,9 +168,6 @@ module.exports = grunt => {
         jsdoc: {
             dist: {
                 src: [
-                    'src/music21_modules.js',
-                    'src/music21/*.js',
-                    'src/music21/*/*.js',
                     'src/music21/*.ts',
                     'src/music21/*/*.ts',
                     'README.md',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "music21j",
   "version": "0.11.11",
   "description": "A toolkit for computer-aided musicology, Javascript version",
-  "main": "releases/main.js",
+  "main": "releases/music21.debug.js",
+  "typings": "releases/main.d.ts",
   "files": [
     ".editorconfig",
     ".eslintignore",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "/ext",
     "/releases",
     "/scripts",
-    "/src/music21",
-    "/src/*.js",
+    "/src",
     "/testHTML",
     "/tests",
     "/webResources"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "music21j",
   "version": "0.11.11",
   "description": "A toolkit for computer-aided musicology, Javascript version",
-  "main": "src/music21_modules.js",
+  "main": "releases/main.js",
   "files": [
     ".editorconfig",
     ".eslintignore",
@@ -10,6 +10,7 @@
     ".gitignore",
     ".jshintrc",
     "Gruntfile.js",
+    "tsconfig.json",
     "/css",
     "/ext",
     "/releases",

--- a/scripts/postinstall.bash
+++ b/scripts/postinstall.bash
@@ -8,8 +8,8 @@ curl https://codeload.github.com/cuthbertLab/midi-js-soundfonts/zip/master > sou
 (cd "${BASEDIR}"/soundfonts || exit 1; unzip -q soundfonts.zip && rm soundfonts.zip)
 
 # do not use the double-bracket form -- Ubuntu 16 cannot handle it and is still supported.
-if [ ! -f "${BASEDIR}/src/music21.js" ]; then
-    echo 'Symlinking music21.js for use with require'
+# if [ ! -f "${BASEDIR}/src/music21.js" ]; then
+#     echo 'Symlinking music21.js for use with require'
 
-    (cd "${BASEDIR}"/src || exit 1; ln -s ../releases/music21.debug.js music21.js)
-fi
+#     (cd "${BASEDIR}"/src || exit 1; ln -s ../releases/music21.debug.js music21.js)
+# fi

--- a/src/note.ts
+++ b/src/note.ts
@@ -819,5 +819,3 @@ export class Rest extends GeneralNote {
         return vfn;
     }
 }
-
-/* ------ TODO(msc): SpacerRest  or remove from music21p ------ */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
         "experimentalDecorators": true,
         "moduleResolution": "node",
         "sourceMap": true,
+        "declaration": true,
+        "declarationMap": true,
+        "declarationDir": "build",
         "target": "es6"
     },
     "include": [


### PR DESCRIPTION
Thanks for your patience @mttbernardini, I've added you as a co-author here so that you're credited as a repo contributor.

Fixes #58 (I'll open an issue for the second issue you mentioned)

We were waiting to fix the entry point issue until we verified we could still consume music21j's declared types in other projects when using this slimmer import of `import * as music21 from "music21j";`, which is FANTASTIC. To that end, I had to adjust the entry-point based on some changes in #93 (`main.js` instead of `debug.js`)

***

@mscuthbert this is intended to supersede both #60 and the `refactor_for_load` branch. Whatever existing procedure you have to copy files from `build` to `releases` at release-time should pick up the type declarations.