### PR TITLE
Revert change to return type of recurse()

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -794,9 +794,6 @@ export class Stream extends base.Music21Object {
         if (classFilter !== undefined) {
             ri.addFilter(new filters.ClassFilter(classFilter));
         }
-        if (streamsOnly) {
-            return ri as iterator.RecursiveIterator<Stream>;
-        }
         return ri;
     }
 
@@ -1322,7 +1319,7 @@ export class Stream extends base.Music21Object {
             streamsOnly: true,
             restoreActiveSites: false,
         })) {
-            if (elSites.includes(s)) {
+            if (elSites.includes(s as Stream)) {
                 if (setActiveSite) {
                     el.activeSite = s;
                 }


### PR DESCRIPTION
My change in #117 actually degraded the return type to `any`, so I suggest reverting it.