### PR TITLE
Remove tsdoc errors

### DIFF
--- a/src/articulations.ts
+++ b/src/articulations.ts
@@ -1,11 +1,5 @@
 /**
- * articulations module. See {@link music21.articulations} namespace
- *
- * @namespace music21.articulations
- * @memberof music21
- * @requires music21/prebase
- * @requires vexflow
- * @requires music21/common
+ * articulations module.
  */
 import Vex from 'vexflow';
 
@@ -70,10 +64,8 @@ export function setPlacementOnVexFlowArticulation(
 
 /**
  * Represents a single articulation, usually in the `.articulations` Array
- * on a {@link music21.note.Note} or something like that.
+ * on a music21.note.Note or something like that.
  *
- * @class Articulation
- * @memberof music21.articulations
  * @property {string} name
  * @property {string} [placement='above']
  * @property {string|undefined} vexflowModifier - the string code to get this accidental in Vexflow
@@ -91,8 +83,6 @@ export class Articulation extends prebase.ProtoM21Object {
 
     /**
      * Generates a Vex.Flow.Articulation for this articulation.
-     *
-     * @returns {Vex.Flow.Articulation}
      */
     vexflow({stemDirection}: VexflowArticulationParams = {}): Vex.Flow.Articulation {
         const vfa = new Vex.Flow.Articulation(this.vexflowModifier);
@@ -103,9 +93,6 @@ export class Articulation extends prebase.ProtoM21Object {
 
 /**
  * base class for articulations that change the length of a note...
- *
- * @class LengthArticulation
- * @memberof music21.articulations
  */
 export class LengthArticulation extends Articulation {
     static get className() { return 'music21.articulation.LengthArticulation'; }
@@ -118,9 +105,6 @@ export class LengthArticulation extends Articulation {
 
 /**
  * base class for articulations that change the dynamic of a note...
- *
- * @class DynamicArticulation
- * @memberof music21.articulations
  */
 export class DynamicArticulation extends Articulation {
     static get className() { return 'music21.articulation.DynamicArticulation'; }
@@ -133,9 +117,6 @@ export class DynamicArticulation extends Articulation {
 
 /**
  * base class for articulations that change the pitch of a note...
- *
- * @class PitchArticulation
- * @memberof music21.articulations
  */
 export class PitchArticulation extends Articulation {
     static get className() { return 'music21.articulation.PitchArticulation'; }
@@ -148,9 +129,6 @@ export class PitchArticulation extends Articulation {
 
 /**
  * base class for articulations that change the timbre of a note...
- *
- * @class TimbreArticulation
- * @memberof music21.articulations
  */
 export class TimbreArticulation extends Articulation {
     static get className() { return 'music21.articulation.TimbreArticulation'; }
@@ -163,9 +141,6 @@ export class TimbreArticulation extends Articulation {
 
 /**
  * 50% louder than usual
- *
- * @class Accent
- * @memberof music21.articulations
  */
 export class Accent extends DynamicArticulation {
     static get className() { return 'music21.articulation.Accent'; }
@@ -180,9 +155,6 @@ export class Accent extends DynamicArticulation {
 
 /**
  * 100% louder than usual
- *
- * @class StrongAccent
- * @memberof music21.articulations
  */
 export class StrongAccent extends Accent {
     static get className() { return 'music21.articulation.StrongAccent'; }
@@ -197,9 +169,6 @@ export class StrongAccent extends Accent {
 
 /**
  * no playback for now.
- *
- * @class Staccato
- * @memberof music21.articulations
  */
 export class Staccato extends LengthArticulation {
     static get className() { return 'music21.articulation.Staccato'; }
@@ -213,9 +182,6 @@ export class Staccato extends LengthArticulation {
 
 /**
  * no playback for now.
- *
- * @class Staccatissimo
- * @memberof music21.articulations
  */
 export class Staccatissimo extends Staccato {
     static get className() { return 'music21.articulation.Staccatissimo'; }
@@ -229,9 +195,6 @@ export class Staccatissimo extends Staccato {
 
 /**
  * no playback or display for now.
- *
- * @class Spiccato
- * @memberof music21.articulations
  */
 export class Spiccato extends Staccato {
     static get className() { return 'music21.articulation.Spiccato'; }
@@ -244,9 +207,6 @@ export class Spiccato extends Staccato {
 }
 
 /**
- * @class Marcato
- * @memberof music21.articulations
- *
  * should be both a DynamicArticulation and a LengthArticulation
  * TODO(msc): check that `.classes` reflects that in music21j
  */
@@ -262,10 +222,6 @@ export class Marcato extends DynamicArticulation {
     }
 }
 
-/**
- * @class Tenuto
- * @memberof music21.articulations
- */
 export class Tenuto extends LengthArticulation {
     static get className() { return 'music21.articulation.Tenuto'; }
 

--- a/src/audioSearch.ts
+++ b/src/audioSearch.ts
@@ -57,8 +57,6 @@ export const config = new _ConfigSingletonCreator();
  * Note: audioRecording uses the newer getUserMedia routines, so
  * this should be ported to be similar to there.
  *
- * @function music21.audioSearch.getUserMedia
- * @memberof music21.audioSearch
  * @param {Object} dictionary - optional dictionary to fill
  * @param {function} callback - callback on success
  * @param {function} error - callback on error

--- a/src/audioSearch.ts
+++ b/src/audioSearch.ts
@@ -1,10 +1,5 @@
 /**
  * audioSearch module. See music21.audioSearch namespace
- *
- * @exports music21/audioSearch
- * @memberof music21
- * @requires music21/pitch
- * @requires music21/common
  */
 import * as MIDI from 'midicube';
 import * as common from './common';

--- a/src/base.ts
+++ b/src/base.ts
@@ -7,15 +7,7 @@
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  *
- * module for Music21Objects, see {@link music21.base}
- *
- * @requires music21/common
- * @requires music21/duration
- * @requires music21/prebase
- * @requires music21/sites
- * @exports music21/base
- * @namespace music21.base
- * @memberof music21
+ * module for Music21Objects
  */
 import * as common from './common';
 import * as derivation from './derivation';
@@ -42,8 +34,6 @@ declare interface StreamRecursionLike {
  * @property {number} classSortOrder - Default sort order for this class
  *     (default 20; override in other classes). Lower numbered objects will sort
  *     before other objects in the staff if priority and offset are the same.
- * @property {music21.duration.Duration} duration - the duration (object) for
- *     the element. (can be set with a quarterLength also)
  * @property {string[]} groups - An Array of strings representing group
  *     (equivalent to css classes) to assign to the object. (default [])
  * @property {boolean} isMusic21Object - true
@@ -559,6 +549,7 @@ export class Music21Object extends prebase.ProtoM21Object {
     repeatAppend(this, item, numberOfTimes) {
         let unused = null;
         try {
+            // noinspection JSUnusedAssignment
             unused = item.isStream;
         } catch (AttributeError) {
             throw new StreamException('to put a non Music21Object in a stream, '

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -31,8 +31,6 @@ export const beamableDurationTypes = [
 /**
  * Object representing a single beam (e.g., a 16th note that is beamed needs two)
  *
- * @class Beam
- * @memberof music21.beam
  * @param {string} type - "start", "stop", "continue", "partial"
  * @param {string} direction - only needed for partial beams: "left" or "right"
  * @property {number|undefined} number - which beam line does this refer to;
@@ -57,8 +55,6 @@ export class Beam extends prebase.ProtoM21Object {
 /**
  * Object representing a collection of Beams
  *
- * @class Beams
- * @memberof music21.beam
  * @property {Beam[]} beamsList - a list of Beam objects
  * @property {boolean} [feathered=false] - is this a feathered beam.
  * @property {number} length - length of beamsList

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -5,14 +5,8 @@
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  *
- * Module holding beam materials. See {@link music21.beam} namespace.
- * {@link music21.beam.Beam} and {music21.beam.Beams} objects
+ * Module holding beam materials.
  *
- * @exports music21/beam
- * @namespace music21.beam
- * @memberof music21
- * @requires music21/prebase
- * @requires music21/duration
  */
 import { Music21Exception } from './exceptions21';
 

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -280,7 +280,8 @@ export class Chord extends note.NotRest {
      *
      * runSort - Sort after running (default true)
      */
-    add(n: string|string[]|note.Note|note.Note[]|pitch.Pitch|pitch.Pitch[],
+    add(
+        n: string|string[]|note.Note|note.Note[]|pitch.Pitch|pitch.Pitch[],
         runSort: boolean = true
     ): this {
         let notes: Array<string|note.Note|pitch.Pitch>;

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -53,7 +53,9 @@ export class Chord extends note.NotRest {
         } else if (typeof notes === 'string') {
             arrayNotes = notes.split(/\s+/);
         } else if (!(notes instanceof Array)) {
-            arrayNotes = [(notes as (note.Note|pitch.Pitch))];
+            arrayNotes = [notes as (note.Note|pitch.Pitch)];
+        } else {
+            arrayNotes = notes;
         }
 
         for (const n of arrayNotes) {

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -5,14 +5,8 @@
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  *
- * Clef module, see {@link music21.clef} for namespace
  * Clef related objects and properties
  *
- * @exports music21/clef
- * @namespace music21.clef
- * @memberof music21
- * @requires music21/base
- * @requires music21/pitch
  */
 import * as base from './base';
 import * as pitch from './pitch';
@@ -24,13 +18,9 @@ import { Stream } from './stream'; // for typing only
 
 // TODO: Fix to newest Vexflow format...
 
-/**
- *
- * @type {
- *     {bass: number, soprano: number, tenor: number, percussion: number,
- *     'mezzo-soprano': number, alto: number, treble: number}}
- */
-export const lowestLines = {
+type ClefName = 'treble'|'soprano'|'mezzo-soprano'|'alto'|'tenor'|'bass'|'percussion';
+
+export const lowestLines: Record<ClefName, number> = {
     treble: 31,
     soprano: 29,
     'mezzo-soprano': 27,
@@ -40,13 +30,7 @@ export const lowestLines = {
     percussion: 31,
 };
 
-/**
- *
- * @type {
- *     {bass: number, soprano: number, tenor: number, percussion: number,
- *     'mezzo-soprano': number, alto: number, treble: number}}
- */
-export const nameToLine = {
+export const nameToLine: Record<ClefName, number> = {
     treble: 2,
     soprano: 1,
     'mezzo-soprano': 2,
@@ -56,13 +40,7 @@ export const nameToLine = {
     percussion: 3,
 };
 
-/**
- *
- * @type {
- *     {bass: string, soprano: string, tenor: string, percussion: string,
- *     'mezzo-soprano': string, alto: string, treble: string}}
- */
-export const nameToSign = {
+export const nameToSign: Record<ClefName, string> = {
     treble: 'G',
     soprano: 'C',
     'mezzo-soprano': 'C',
@@ -76,14 +54,11 @@ export const nameToSign = {
  * Clef name can be one of
  * "treble", "bass", "soprano", "mezzo-soprano", "alto", "tenor", "percussion"
  *
- * @param {string} name - clef name
- * @param {number} [octaveChange=0] - ottava
- * @property {string} [name]
- * @property {number} lowestLine - diatonicNoteNum (C4 = 29) for the
+ * lowestLine - diatonicNoteNum (C4 = 29) for the
  *     lowest line (in a five-line staff)
- * @property {number} lowestLineTrebleOffset - difference between the first line
+ * lowestLineTrebleOffset - difference between the first line
  *     of this staff and the first line in treble clef
- * @property {number} octaveChange
+ * octaveChange
  */
 export class Clef extends base.Music21Object {
     static get className() { return 'music21.clef.Clef'; }
@@ -95,12 +70,12 @@ export class Clef extends base.Music21Object {
     lowestLine: number = lowestLines.treble;
     lowestLineTrebleOffset: number = 0;
 
-    constructor(name?: string, octaveChange: number = 0) {
+    constructor(name?: ClefName, octaveChange: number = 0) {
         super();
         this.classSortOrder = 0;
 
         if (name !== undefined) {
-            name = name.toLowerCase();
+            name = name.toLowerCase() as ClefName;
             this.name = name;
             this.lowestLine = lowestLines[name];
             this.sign = nameToSign[name];
@@ -159,7 +134,7 @@ export class Clef extends base.Music21Object {
             throw new Error('getStemDirectionForPitches cannot operate on an empty Array');
         }
 
-        let relevantPitches: pitch.Pitch[] = [];
+        let relevantPitches: pitch.Pitch[];
         if (extremePitchOnly) {
             pitchRealList.sort((a, b) => a.diatonicNoteNum - b.diatonicNoteNum);
             const pitchMin = pitchRealList[0];
@@ -187,10 +162,6 @@ export class Clef extends base.Music21Object {
 
 /**
  * A TrebleClef (same as new music21.clef.Clef('treble'))
- *
- * @class TrebleClef
- * @memberof music21.clef
- * @extends music21.clef.Clef
  */
 export class TrebleClef extends Clef {
     static get className() { return 'music21.clef.TrebleClef'; }
@@ -206,10 +177,6 @@ export class TrebleClef extends Clef {
  * A TrebleClef down an octave (same as new music21.clef.Clef('treble', -1))
  *
  * Unlike music21p, currently not a subclass of TrebleClef.
- *
- * @class Treble8vbClef
- * @memberof music21.clef
- * @extends music21.clef.Clef
  */
 export class Treble8vbClef extends Clef {
     static get className() { return 'music21.clef.Treble8vbClef'; }
@@ -221,10 +188,6 @@ export class Treble8vbClef extends Clef {
 
 /**
  * A TrebleClef up an octave (same as new music21.clef.Clef('treble', 1))
- *
- * @class Treble8vaClef
- * @memberof music21.clef
- * @extends music21.clef.Clef
  */
 export class Treble8vaClef extends Clef {
     static get className() { return 'music21.clef.Treble8vaClef'; }
@@ -236,10 +199,6 @@ export class Treble8vaClef extends Clef {
 
 /**
  * A BassClef (same as new music21.clef.Clef('bass'))
- *
- * @class BassClef
- * @memberof music21.clef
- * @extends music21.clef.Clef
  */
 export class BassClef extends Clef {
     static get className() { return 'music21.clef.BassClef'; }
@@ -253,10 +212,6 @@ export class BassClef extends Clef {
 
 /**
  * A BassClef down an octave (same as new music21.clef.Clef('bass', -1))
- *
- * @class Bass8vbClef
- * @memberof music21.clef
- * @extends music21.clef.Clef
  */
 export class Bass8vbClef extends Clef {
     static get className() { return 'music21.clef.Bass8vbClef'; }
@@ -270,10 +225,6 @@ export class Bass8vbClef extends Clef {
 
 /**
  * An AltoClef (same as new music21.clef.Clef('alto'))
- *
- * @class AltoClef
- * @memberof music21.clef
- * @extends music21.clef.Clef
  */
 export class AltoClef extends Clef {
     static get className() { return 'music21.clef.AltoClef'; }
@@ -287,10 +238,6 @@ export class AltoClef extends Clef {
 
 /**
  * A Tenor Clef (same as new music21.clef.Clef('tenor'))
- *
- * @class TenorClef
- * @memberof music21.clef
- * @extends music21.clef.Clef
  */
 export class TenorClef extends Clef {
     static get className() { return 'music21.clef.TenorClef'; }
@@ -304,10 +251,6 @@ export class TenorClef extends Clef {
 
 /**
  * A Soprano Clef (same as new music21.clef.Clef('soprano'))
- *
- * @class SopranoClef
- * @memberof music21.clef
- * @extends music21.clef.Clef
  */
 export class SopranoClef extends Clef {
     static get className() { return 'music21.clef.SopranoClef'; }
@@ -321,10 +264,6 @@ export class SopranoClef extends Clef {
 
 /**
  * A Mezzo-Soprano Clef (same as new music21.clef.Clef('mezzo-soprano'))
- *
- * @class MezzoSopranoClef
- * @memberof music21.clef
- * @extends music21.clef.Clef
  */
 export class MezzoSopranoClef extends Clef {
     static get className() { return 'music21.clef.MezzoSopranoClef'; }
@@ -340,10 +279,6 @@ export class MezzoSopranoClef extends Clef {
  * A Percussion Clef (same as new music21.clef.Clef('percussion'))
  *
  * First line is treated as if it's treble clef. Not available as "bestClef"
- *
- * @class PercussionClef
- * @memberof music21.clef
- * @extends music21.clef.Clef
  */
 export class PercussionClef extends Clef {
     static get className() { return 'music21.clef.PercussionClef'; }
@@ -411,12 +346,8 @@ export function bestClef(st: Stream, { recurse=true }={}): Clef {
 }
 
 /**
- *
- * @param {string} clefString
- * @param {number} [octaveShift=0]
- * @returns {music21.clef.Clef}
  */
-export function clefFromString(clefString, octaveShift=0) {
+export function clefFromString(clefString: string, octaveShift: number = 0): Clef {
     const xnStr = clefString.trim();
     let thisType;
     let lineNum;
@@ -472,6 +403,6 @@ export function clefFromString(clefString, octaveShift=0) {
     } else if (arrayEqual(params, ['C', 4, 0])) {
         return new TenorClef();
     } else {
-        return new Clef(xnStr, octaveShift);
+        return new Clef(xnStr as ClefName, octaveShift);
     }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -43,13 +43,11 @@ export function coerceHTMLElement(el?: JQuery|HTMLElement): HTMLElement {
  * http://stackoverflow.com/questions/171251/how-can-i-merge-properties-of-two-javascript-objects-dynamically
  * recursive parts used in .clone()
  *
- * @function music21.common.merge
  * @param {Object} destination - object to have attributes placed into
  * @param {Object} source - object to take attributes from.
- * @memberof music21.common
  * @returns {Object} destination
  */
-export function merge(destination, source) {
+export function merge(destination: object, source?: object): object {
     if (source === undefined || source === null) {
         return destination;
     }
@@ -173,9 +171,8 @@ export function posMod(a, b) {
  * In case of tie, returns the first element to reach the maximum
  * number of occurrences.
  *
- * @function music21.common.statisticalMode
  * @param {Array<*>} a - an array to analyze
- * @returns {Object} element with the highest frequency in a
+ * @returns {Object} element with the highest frequency in an array.
  */
 export function statisticalMode(a) {
     if (a.length === 0) {
@@ -278,13 +275,10 @@ export function toRoman(num) {
 /**
  * Creates an SVGElement of an SVG figure using the correct `document.createElementNS` call.
  *
- * @function music21.common.makeSVGright
  * @param {string} [tag='svg'] - a tag, such as 'rect', 'circle', 'text', or 'svg'
  * @param {Object} [attrs] - attributes to pass to the tag.
- * @memberof music21.common
- * @returns {SVGElement}
  */
-export function makeSVGright(tag='svg', attrs={}) {
+export function makeSVGright(tag='svg', attrs={}): SVGElement {
     // see http://stackoverflow.com/questions/3642035/jquerys-append-not-working-with-svg-element
     // normal JQuery does not work.
     const el = document.createElementNS('http://www.w3.org/2000/svg', tag);
@@ -301,12 +295,9 @@ export function makeSVGright(tag='svg', attrs={}) {
  * Take a number such as 32 and return a string such as "nd"
  * (for "32nd") etc.
  *
- * @function music21.common.ordinalAbbreviation
- * @param {number} value
- * @param {boolean} [plural=false] - make plural (note that "21st" plural is "21st")
- * @return {string}
+ * [plural=false] - make plural (note that "21st" plural is "21st")
  */
-export function ordinalAbbreviation(value: number, plural: boolean = false) {
+export function ordinalAbbreviation(value: number, plural: boolean = false): string {
     let post: string;
     const valueHundredths = value % 100;
     if (
@@ -336,7 +327,6 @@ export function ordinalAbbreviation(value: number, plural: boolean = false) {
 /**
  * Find a rational number approximation of this floating point.
  *
- * @function music21.common.rationalize
  * @param {number} ql - number to rationalize
  * @param {number} [epsilon=0.001] - how close to get
  * @param {int} [maxDenominator=50] - maximum denominator
@@ -359,11 +349,9 @@ export function rationalize(ql: number, epsilon=0.001, maxDenominator=50) {
  *
  * "400px" -> 400
  *
- * @function music21.common.stripPx
- * @param {number|string} str -- string that might have 'px' at the end or not
- * @returns {number} a number to use
+ * str -- string that might have 'px' at the end or not
  */
-export function stripPx(str) {
+export function stripPx(str: number|string): number {
     if (typeof str === 'string') {
         const pxIndex = str.indexOf('px');
         str = str.slice(0, pxIndex);
@@ -376,11 +364,10 @@ export function stripPx(str) {
 /**
  * Find name in the query string (?name=value) and return value.
  *
- * @function music21.common.urlParam
- * @param {string} name - url parameter to find
- * @returns {string} may be "" if empty.
+ * name - url parameter to find
+ * Return may be '' if empty.
  */
-export function urlParam(name) {
+export function urlParam(name: string): string {
     name = name.replace(/[[]/, '\\[').replace(/[\]]/, '\\]');
     const regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
     const results = regex.exec(window.location.search);

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,10 +1,42 @@
 /**
  * common functions
  * functions that are useful everywhere...
- *
- * @exports music21/common
- * @memberof music21
  */
+
+
+import * as $ from 'jquery';
+
+/**
+ *  Many music21j functions take either JQuery or HTMLElement, but
+ *  "el instanceof $" is not a good way of checking, because the copy of
+ *  JQuery imported into music21j might not be the same copy loaded by a calling
+ *  library or script tag.  Hence these three little functions that coerce in one
+ *  direction or another.
+ */
+export function jQueryAndHTMLVersion(el?: JQuery|HTMLElement): [JQuery, HTMLElement] {
+    let $jq: JQuery;
+    let htmlElement: HTMLElement;
+    if (el !== undefined && (el as JQuery).jquery !== undefined) {
+        $jq = (el as JQuery);
+        htmlElement = (el as JQuery)[0];
+    } else if (el instanceof HTMLElement) {
+        htmlElement = el;
+        $jq = $(el);
+    } else {
+        $jq = $('body');
+        htmlElement = $jq[0];
+    }
+    return [$jq, htmlElement];
+}
+
+export function coerceJQuery(el?: JQuery|HTMLElement): JQuery {
+    return jQueryAndHTMLVersion(el)[0];
+}
+
+export function coerceHTMLElement(el?: JQuery|HTMLElement): HTMLElement {
+    return jQueryAndHTMLVersion(el)[1];
+}
+
 
 /**
  * concept borrowed from Vex.Flow.Merge, though here the source can be undefined;

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -5,18 +5,8 @@
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21, Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  *
- * Module that holds **music21** classes and
- * tools for dealing with durations, especially
- * the {@link music21.duration.Duration} class.
+ * Duration module.
  *
- * Duration module. See {@link music21.duration}
- *
- * @module music21/duration
- * @namespace music21.duration
- * @memberof music21
- * @requires music21/common
- * @requires music21/prebase
- * @exports music21/duration
  */
 import { Music21Exception } from './exceptions21';
 
@@ -26,9 +16,6 @@ import * as prebase from './prebase';
 
 /**
  * Object mapping int to name, as in `{1: 'whole'}` etc.
- *
- * @memberof music21.duration
- * @type {Object}
  */
 export const typeFromNumDict = {
     1: 'whole',
@@ -89,11 +76,7 @@ export const vexflowDurationArray = [
 
 /**
  * Duration object; found as the `.duration` attribute on Music21Object instances
- * such as {@link music21.note.Note}
- *
- * @class Duration
- * @memberof music21.duration
- * @param {(number|undefined)} ql - quarterLength (default 1.0)
+ * such as music21.note.Note
  */
 export class Duration extends prebase.ProtoM21Object {
     static get className() { return 'music21.duration.Duration'; }
@@ -202,11 +185,8 @@ export class Duration extends prebase.ProtoM21Object {
      * Reads the tuplet Array for the duration.
      *
      * The tuplet array should be considered Read Only.
-     * Use {@link music21.duration.Duration#appendTuplet} to
+     * Use music21.duration.Duration#appendTuplet to
      * add a tuplet (no way to remove yet)
-     *
-     * @type {Tuplet[]}
-     * @default []
      */
     get tuplets(): Tuplet[] {
         return this._tuplets;
@@ -347,14 +327,13 @@ export class Duration extends prebase.ProtoM21Object {
 }
 
 /**
- * Represents a Tuplet; found in {@link music21.duration.Duration#tuplets}
+ * Represents a Tuplet; found in music21.duration.Duration#tuplets
  *
- * @memberof music21.duration
- * @param {number} [numberNotesActual=3] - numerator of the tuplet
- * @param {number} [numberNotesNormal=2] - denominator of the tuplet
- * @param {(music21.duration.Duration|number)} [durationActual] - duration or
+ * [numberNotesActual=3] - numerator of the tuplet
+ * [numberNotesNormal=2] - denominator of the tuplet
+ * [durationActual] - duration or
  *     quarterLength of duration type, default music21.duration.Duration(0.5)
- * @param {(music21.duration.Duration|number)} [durationNormal] - unused;
+ * [durationNormal] - unused;
  *     see music21p for description
  */
 export class Tuplet extends prebase.ProtoM21Object {
@@ -371,17 +350,20 @@ export class Tuplet extends prebase.ProtoM21Object {
     tupletNormalShow: string;
 
     constructor(
-        numberNotesActual=3,
-        numberNotesNormal=2,
-        durationActual=undefined,
-        durationNormal=undefined
+        numberNotesActual: number = 3,
+        numberNotesNormal: number = 2,
+        durationActual?: Duration|number,
+        durationNormal?: Duration|number
     ) {
         super();
         this.numberNotesActual = numberNotesActual;
         this.numberNotesNormal = numberNotesNormal;
+        if (typeof durationActual === 'number') {
+            durationActual = new Duration(durationActual);
+        }
         this.durationActual = durationActual || new Duration(0.5);
-        if (typeof this.durationActual === 'number') {
-            this.durationActual = new Duration(this.durationActual);
+        if (typeof durationNormal === 'number') {
+            durationNormal = new Duration(durationNormal);
         }
         this.durationNormal = durationNormal || this.durationActual;
 
@@ -437,10 +419,10 @@ export class Tuplet extends prebase.ProtoM21Object {
     /**
      * Set both durationActual and durationNormal for the tuplet.
      *
-     * @param {string} type - a duration type, such as `half`, `quarter`
-     * @returns {music21.duration.Duration} A converted {@link music21.duration.Duration} matching `type`
+     * type - a duration type, such as `half`, `quarter`
+     * returns A converted music21.duration.Duration matching `type`
      */
-    setDurationType(type) {
+    setDurationType(type: string): Duration {
         if (this.frozen === true) {
             throw new Music21Exception(
                 'A frozen tuplet (or one attached to a duration) is immutable'

--- a/src/dynamics.ts
+++ b/src/dynamics.ts
@@ -7,16 +7,10 @@
  *
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
- * dynamics Module. See {@link music21.dynamics} for namespace
  *
  * Dynamics related objects.
  *
  * Currently do not export to Vexflow.  :-(
- *
- * @exports music21/dynamics
- * @namespace music21.dynamics
- * @memberof music21
- * @requires music21/base
  */
 import * as base from './base';
 
@@ -85,9 +79,6 @@ export const dynamicStrToScalar = {
 /**
  * A representation of a dynamic.
  *
- * @class Dynamic
- * @memberof music21.dynamics
- * @extends music21.base.Music21Object
  * @param {number|string} value - either a number between 0 and 1 or a dynamic mark such as "ff" or "mp"
  * @property {string|undefined} value - a name such as "pp" etc.
  * @property {string|undefined} longName - a longer name such as "pianissimo"

--- a/src/expressions.ts
+++ b/src/expressions.ts
@@ -1,11 +1,6 @@
 /**
- * Expressions module.  See {@link music21.expressions}
  * Expressions can be note attached (`music21.note.Note.expressions[]`) or floating...
  *
- * @exports music21/expressions
- * @namespace music21.expressions
- * @memberof music21
- * @requires music21/expressions
  */
 
 import Vex from 'vexflow';
@@ -19,9 +14,6 @@ import {
 /**
  * Expressions can be note attached (`music21.note.Note.expressions[]`) or floating...
  *
- * @class Expression
- * @memberof music21.expressions
- * @extends music21.base.Music21Object
  * @property {string} name
  * @property {string} vexflowModifier
  * @property {number} setPosition
@@ -37,8 +29,6 @@ export class Expression extends base.Music21Object {
      * Renders this Expression as a Vex.Flow.Articulation
      *
      * (this is not right for all cases)
-     *
-     * @returns {Vex.Flow.Articulation}
      */
     vexflow({stemDirection}: VexflowArticulationParams = {}): Vex.Flow.Articulation {
         const vfe = new Vex.Flow.Articulation(this.vexflowModifier);
@@ -50,9 +40,6 @@ export class Expression extends base.Music21Object {
 /**
  * A fermata...
  *
- * @class Fermata
- * @memberof music21.expressions
- * @extends music21.expressions.Expression
  */
 export class Fermata extends Expression {
     static get className() { return 'music21.expressions.Fermata'; }

--- a/src/figuredBass.ts
+++ b/src/figuredBass.ts
@@ -1,7 +1,3 @@
-/**
- * @namespace music21.figuredBass
- * @exports music21/figuredBass
- */
 import * as pitch from './pitch';
 
 const shorthandNotation = {
@@ -22,9 +18,6 @@ const shorthandNotation = {
  */
 
 
-/**
- * @memberof music21.figuredBass
- */
 export class Notation {
     notationColumn: string;
     figureStrings: string[] = undefined;
@@ -61,19 +54,16 @@ export class Notation {
      *    and this.modifierStrings, which provide the intervals above the
      *    bass and (if necessary) how to modify the corresponding pitches
      *    accordingly.
-     *
-     * @return {undefined}
      */
-
-    _parseNotationColumn() {
+    _parseNotationColumn(): void {
         const nc = this.notationColumn;
         const figures = nc.split(/,/);
         const numbers = [];
         const modifierStrings = [];
         const figureStrings = [];
 
-        for (let figure of figures) {
-            figure = figure.trim();
+        for (const fig of figures) {
+            const figure = fig.trim();
             figureStrings.push(figure);
             let numberString = '';
             let modifierString = '';
@@ -102,7 +92,7 @@ export class Notation {
 
     _translateToLonghand() {
         let oldNumbers = this.numbers;
-        let newNumbers = oldNumbers;
+        let newNumbers;
         const oldModifierStrings = this.modifierStrings;
         let newModifierStrings = oldModifierStrings;
         const oldNumbersString = oldNumbers.toString();
@@ -165,9 +155,6 @@ export class Notation {
     }
 }
 
-/**
- * @memberOf music21.figuredBass
- */
 export class Figure {
     number: number;
     modifierString: string;
@@ -193,9 +180,6 @@ const specialModifiers = {
     '++++': '####',
 };
 
-/**
- * @memberOf music21.figuredBass
- */
 export class Modifier {
     modifierString: string;
     accidental: pitch.Accidental;

--- a/src/fromPython.ts
+++ b/src/fromPython.ts
@@ -25,16 +25,14 @@
  *
  */
 import * as jsonpickle from 'jsonpickle';
+import type * as stream from './stream';
 
 const jp = jsonpickle;
 const unpickler = jp.unpickler;
 
-import type * as stream from './stream';
 
 /**
  *
- * @class Converter
- * @memberof music21.fromPython
  * @property {boolean} debug
  * @property {Array<string>} knownUnparsables - list of classes that cannot be parsed
  * @property {Object} handlers - object mapping string names of classes to a set of

--- a/src/fromPython.ts
+++ b/src/fromPython.ts
@@ -5,8 +5,6 @@
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  *
- * fromPython module -- see {@link music21.fromPython}
- *
  * Converter for taking a Python-encoded jsonpickle music21p stream
  * and loading it into music21j
  *
@@ -14,9 +12,6 @@
  *
  * Requires Cuthbert's jsonpickle.js port.
  *
- * @namespace music21.fromPython
- * @extends music21
- * @requires jsonpickle
  * @example
  * in python:
  *
@@ -33,6 +28,8 @@ import * as jsonpickle from 'jsonpickle';
 
 const jp = jsonpickle;
 const unpickler = jp.unpickler;
+
+import type * as stream from './stream';
 
 /**
  *
@@ -109,11 +106,10 @@ export class Converter {
     /**
      * Fixes up some references that cannot be unpacked from jsonpickle.
      *
-     * @param {music21.stream.Stream} s - stream after unpacking from jsonpickle
-     * @returns {music21.stream.Stream}
+     * s - stream after unpacking from jsonpickle
      */
-    streamPostRestore(s) {
-        const st = s._storedElementOffsetTuples;
+    streamPostRestore(s: stream.Stream): stream.Stream {
+        const st = (s as any)._storedElementOffsetTuples;
 
         s._clef = this.lastClef;
         s._keySignature = this.lastKeySignature;
@@ -191,9 +187,6 @@ export class Converter {
 
     /**
      * Run the main decoder
-     *
-     * @param {string} jss - stream encoded as JSON
-     * @returns {music21.stream.Stream}
      */
     run(jss) {
         const outStruct = unpickler.decode(jss, this.handlers);

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -6,11 +6,10 @@
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  */
 import * as base from './base';
+import type * as interval from './interval';
 
 export const global_usedChannels: number[] = []; // differs from m21p -- stored midiProgram numbers
 export const maxMidi: number = 16;
-
-import type * as interval from './interval';
 
 interface InstrumentFileInfo {
     fn: string,
@@ -184,8 +183,6 @@ export const info: InstrumentFileInfo[] = [
  * See music21.miditools and esp. `loadSoundfont` for a way of loading soundfonts into
  * instruments.
  *
- * @class Instrument
- * @memberof music21.instrument
  * @param {string} instrumentName
  * @property {string|undefined} partId
  * @property {string|undefined} partName

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -4,26 +4,21 @@
  *
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
- *
- * Instrument module, see {@link music21.instrument}
- * Looking for the {@link music21.instrument.Instrument} object? :-)
- *
- * @exports music21/instrument
- *
- * @namespace music21.instrument
- * @memberof music21
- * @requires music21/base
  */
 import * as base from './base';
 
 export const global_usedChannels: number[] = []; // differs from m21p -- stored midiProgram numbers
 export const maxMidi: number = 16;
 
-/**
- *
- * @type {Array<{fn: string, name: string, midiNumber: number}>}
- */
-export const info = [
+import type * as interval from './interval';
+
+interface InstrumentFileInfo {
+    fn: string,
+    name: string,
+    midiNumber: number,
+}
+
+export const info: InstrumentFileInfo[] = [
     { fn: 'acoustic_grand_piano', name: 'Acoustic Grand Piano', midiNumber: 0 },
     {
         fn: 'bright_acoustic_piano',
@@ -186,7 +181,7 @@ export const info = [
 /**
  * Represents an instrument.  instrumentNames are found in the ext/soundfonts directory
  *
- * See {@link music21.miditools} and esp. `loadSoundfont` for a way of loading soundfonts into
+ * See music21.miditools and esp. `loadSoundfont` for a way of loading soundfonts into
  * instruments.
  *
  * @class Instrument
@@ -202,7 +197,6 @@ export const info = [
  * @property {int|undefined} midiChannel
  * @property {int|undefined} lowestNote
  * @property {int|undefined} highestNote
- * @property {music21.interval.Interval|undefined} transposition
  * @property {Boolean} inGMPercMap=false
  * @property {string|undefined} soundfontFn
  * @property {string|undefined} oggSoundfont - url of oggSoundfont for this instrument
@@ -224,7 +218,7 @@ export class Instrument extends base.Music21Object {
     lowestNote = undefined;
     highestNote = undefined;
 
-    transpostion = undefined;
+    transposition: interval.Interval;
 
     inGMPercMap = false;
     soundfontFn = undefined;
@@ -299,13 +293,10 @@ export class Instrument extends base.Music21Object {
  * Find information for a given instrument (by filename or name)
  * and load it into an instrument object.
  *
- * @function music21.instrument.find
- * @memberof music21.instrument
- * @param {string} fn - name or filename of instrument
- * @param {music21.instrument.Instrument} [inst] - instrument object to load into
- * @returns {music21.instrument.Instrument|undefined}
+ * fn - name or filename of instrument
+ * [inst] - instrument object to load into
  */
-export function find(fn, inst=undefined) {
+export function find(fn: string, inst?: Instrument): Instrument {
     if (inst === undefined) {
         inst = new Instrument();
     }

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -18,7 +18,6 @@ import * as pitch from './pitch';
 /**
  * Interval Directions as an Object/map
  *
- * @memberof music21.interval
  * @example
  * if (music21.interval.Direction.OBLIQUE >
  *     music21.interval.Direction.ASCENDING ) {
@@ -35,7 +34,6 @@ export const Direction = {
 /**
  * N.B. a dict in music21p -- the indexes here let Direction call them + 1
  *
- * @memberof music21.interval
  * @example
  * console.log(music21.interval.IntervalDirectionTerms[music21l.interval.Direction.OBLIQUE + 1])
  * // "Oblique"
@@ -45,7 +43,6 @@ export const IntervalDirectionTerms = ['Descending', 'Oblique', 'Ascending'];
 /**
  * ordinals for music terms...
  *
- * @memberof music21.interval
  * @example
  * for (var i = 1; // N.B. 0 = undefined
  *      i < music21.interval.MusicOrdinals.length;
@@ -84,8 +81,6 @@ export const MusicOrdinals = [
  *
  * Properties are demonstrated below.
  *
- * @class GenericInterval
- * @memberof music21.interval
  * @param {number} [gi=1] - generic interval (1 or higher, or -2 or lower)
  * @example
  * var gi = new music21.interval.GenericInterval(-14)
@@ -754,8 +749,6 @@ export class ChromaticInterval extends prebase.ProtoM21Object {
 export const IntervalStepNames = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
 
 /**
- * @function music21.interval.convertDiatonicNumberToStep
- * @memberof music21.interval
  * @param {number} dn - diatonic number, where 29 = C4, C#4 etc.
  * @returns {Array} two element array of {string} stepName and {number} octave
  */

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -5,15 +5,8 @@
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  *
- * interval module. See {@link music21.interval} for namespace
  * Interval related objects
  *
- * @exports music21/interval
- *
- * @namespace music21.interval
- * @memberof music21
- * @requires music21/prebase
- * @requires music21/pitch
  */
 import { debug } from './debug';
 
@@ -266,20 +259,16 @@ export class GenericInterval extends prebase.ProtoM21Object {
 
     /**
      * Returns a new GenericInterval which is the mod7inversion; 3rds (and 10ths etc.) to 6ths, etc.
-     *
-     * @returns {music21.interval.GenericInterval}
      */
-    complement() {
+    complement(): GenericInterval {
         return new GenericInterval(this.mod7inversion);
     }
 
     /**
      * Returns a new GenericInterval which has the opposite direction
      * (descending becomes ascending, etc.)
-     *
-     * @returns {music21.interval.GenericInterval}
      */
-    reverse() {
+    reverse(): GenericInterval {
         if (this.undirected === 1) {
             return new GenericInterval(1);
         } else {
@@ -292,18 +281,14 @@ export class GenericInterval extends prebase.ProtoM21Object {
     /**
      * Given a specifier, return a new DiatonicInterval with this generic.
      *
-     * @param {string|number} specifier - a specifier such as "P", "m", "M", "A", "dd" etc.
-     * @returns {music21.interval.DiatonicInterval}
+     * specifier - a specifier such as "P", "m", "M", "A", "dd" etc.
      */
-    getDiatonic(specifier: string|number) {
+    getDiatonic(specifier: string|number): DiatonicInterval {
         return new DiatonicInterval(specifier, this);
     }
 
     /**
      * Transpose a pitch by this generic interval, maintaining accidentals
-     *
-     * @param {music21.pitch.Pitch} p
-     * @returns {music21.pitch.Pitch}
      */
     transposePitch(p: pitch.Pitch): pitch.Pitch {
         const pitch2 = new pitch.Pitch();
@@ -462,10 +447,8 @@ export const IntervalAdjustImperf = {
 /**
  * Represents a Diatonic interval.  See example for usage.
  *
- * @class DiatonicInterval
- * @memberof music21.interval
- * @param {string|number|undefined} [specifier='P'] - a specifier such as "P", "d", "m", "M" etc.
- * @param {music21.interval.GenericInterval|number} [generic=1] - a `GenericInterval`
+ * [specifier='P'] - a specifier such as "P", "d", "m", "M" etc.
+ * [generic=1] - a `GenericInterval`
  *              object or a number to be converted to one
  * @example
  * var di = new music21.interval.DiatonicInterval("M", 10);
@@ -510,7 +493,7 @@ export class DiatonicInterval extends prebase.ProtoM21Object {
     invertedOrderedSpecifier: string;  // this is messed up -- should be number...
     mod7inversion: string;
 
-    constructor(specifier: string|number, generic) {
+    constructor(specifier: string|number, generic: number|GenericInterval) {
         super();
 
         if (specifier === undefined) {
@@ -632,8 +615,6 @@ export class DiatonicInterval extends prebase.ProtoM21Object {
 
     /**
      * Returns a ChromaticInterval object of the same size.
-     *
-     * @returns {music21.interval.ChromaticInterval}
      */
     getChromatic(): ChromaticInterval {
         const octaveOffset = Math.floor(
@@ -679,44 +660,20 @@ export class DiatonicInterval extends prebase.ProtoM21Object {
         return new ChromaticInterval(semitones);
     }
 
-    /**
-     *
-     * @param {music21.pitch.Pitch} p
-     * @returns {music21.pitch.Pitch}
-     */
     transposePitch(p: pitch.Pitch): pitch.Pitch {
         const fullIntervalObject = new Interval(this, this.getChromatic());
         return fullIntervalObject.transposePitch(p);
     }
 
-    /**
-     *
-     * @type {string}
-     */
     get specifierAbbreviation(): string {
         return IntervalPrefixSpecs[this.specifier];
     }
 
-    /**
-     *
-     * @returns {number}
-     */
     get cents(): number {
         return this.getChromatic().cents;
     }
 }
 
-/**
- * @class ChromaticInterval
- * @memberof music21.interval
- * @param {number} value - number of semitones (positive or negative)
- * @property {number} cents
- * @property {number} value
- * @property {number} undirected - absolute value of value
- * @property {number} mod12 - reduction to one octave
- * @property {number} intervalClass - reduction to within a tritone (11 = 1, etc.)
- *
- */
 export class ChromaticInterval extends prebase.ProtoM21Object {
     static get className() { return 'music21.interval.ChromaticInterval'; }
 
@@ -767,10 +724,6 @@ export class ChromaticInterval extends prebase.ProtoM21Object {
         }
     }
 
-    /**
-     *
-     * @returns {music21.interval.ChromaticInterval}
-     */
     reverse(): ChromaticInterval {
         return new ChromaticInterval(
             this.undirected * (-1 * this.direction)
@@ -781,9 +734,6 @@ export class ChromaticInterval extends prebase.ProtoM21Object {
 
     /**
      * Transposes pitches but does not maintain accidentals, etc.
-     *
-     * @property {music21.pitch.Pitch} p - pitch to transpose
-     * @returns {music21.pitch.Pitch}
      */
     transposePitch(p: pitch.Pitch): pitch.Pitch {
         let useImplicitOctave = false;
@@ -831,12 +781,10 @@ export function convertDiatonicNumberToStep(
 /**
  * This is the main, powerful Interval class.
  *
- * Instantiate with either a string ("M3") or two {@link music21.pitch.Pitch} or two {@link music21.note.Note}
+ * Instantiate with either a string ("M3") or two music21.pitch.Pitch or two music21.note.Note objects.
  *
  * See music21p instructions for usage.
  *
- * @class Interval
- * @memberof music21.interval
  * @example
  * var n1 = new music21.note.Note("C4");
  * var n2 = new music21.note.Note("F#5");
@@ -936,11 +884,7 @@ export class Interval extends prebase.ProtoM21Object {
         this.reinit();
     }
 
-    /**
-     *
-     * @returns {music21.interval.Interval}
-     */
-    get complement() {
+    get complement(): Interval {
         return new Interval(this.diatonic.mod7inversion);
     }
 
@@ -974,11 +918,7 @@ export class Interval extends prebase.ProtoM21Object {
         this.isSkip = this.diatonic.isSkip;
     }
 
-    /**
-     *
-     * @type {music21.note.Note|undefined}
-     */
-    get noteStart() {
+    get noteStart(): note.Note {
         return this._noteStart;
     }
 
@@ -990,15 +930,11 @@ export class Interval extends prebase.ProtoM21Object {
         this._noteEnd.pitch = p2;
     }
 
-    /**
-     *
-     * @type {music21.note.Note|undefined}
-     */
-    get noteEnd() {
+    get noteEnd(): note.Note {
         return this._noteEnd;
     }
 
-    set noteEnd(n) {
+    set noteEnd(n: note.Note) {
         this._noteEnd = n;
         const p1 = n.pitch;
         const p2 = this.transposePitch(p1, {reverse: true});
@@ -1023,15 +959,13 @@ export class Interval extends prebase.ProtoM21Object {
     //  todo general: microtones
     // noinspection JSUnusedLocalSymbols
     /**
-     * TODO: maxAccidental
-     *
-     * @param {music21.pitch.Pitch} p - pitch to transpose
-     * @param {Object} config - configuration
-     * @param {boolean} [config.reverse=false] -- reverse direction
-     * @param {number} [config.maxAccidental=4] -- maximum accidentals to retain (unused)
-     * @returns {music21.pitch.Pitch}
+     * [config.reverse=false] -- reverse direction
+     * [config.maxAccidental=4] -- maximum accidentals to retain (unused/ TODO)
      */
-    transposePitch(p, { reverse=false, maxAccidental=4 }={}) {
+    transposePitch(
+        p: pitch.Pitch,
+        { reverse=false, maxAccidental=4 }={}
+    ): pitch.Pitch {
         /*
         var useImplicitOctave = false;
         if (p.octave === undefined) {
@@ -1133,7 +1067,7 @@ export function _getSpecifierFromGenericChromatic(
     const noteVals = [undefined, 0, 2, 4, 5, 7, 9, 11];
     const normalSemis
         = noteVals[gInt.simpleUndirected] + 12 * gInt.undirectedOctaves;
-    let theseSemis = 0;
+    let theseSemis;
     if (
         gInt.direction !== cInt.direction
         && gInt.direction !== Direction.OBLIQUE
@@ -1164,12 +1098,7 @@ export function _getSpecifierFromGenericChromatic(
     return specifier;
 }
 
-/**
- *
- * @param {music21.interval.Interval[]} intervalList
- * @returns {music21.interval.Interval}
- */
-export function add(intervalList) {
+export function add(intervalList: Interval[]): Interval {
     const p1 = new pitch.Pitch('C4');
     let p2 = new pitch.Pitch('C4');
     for (const i of intervalList) {

--- a/src/key.ts
+++ b/src/key.ts
@@ -5,17 +5,6 @@
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  *
- * key and key signature module. See {@link music21.key} namespace for details
- * Key and KeySignature related objects and methods
- *
- * @exports music21/key
- *
- * @namespace music21.key
- * @memberof music21
- * @requires music21/base
- * @requires music21/pitch
- * @requires music21/interval
- * @requires music21/scale
  */
 import { Music21Exception } from './exceptions21';
 import { debug } from './debug';
@@ -35,12 +24,7 @@ export const modeSharpsAlter = {
     locrian: -5,
 };
 
-/**
- *
- * @param {string} textString
- * @returns {string}
- */
-export function convertKeyStringToMusic21KeyString(textString) {
+export function convertKeyStringToMusic21KeyString(textString: string): string {
     if (textString === 'bb') {
         textString = 'b-';
     } else if (textString === 'Bb') {
@@ -59,7 +43,6 @@ export function convertKeyStringToMusic21KeyString(textString) {
  * @property {int} [sharps=0] -- number of sharps (negative for flats)
  * @property {string[]} flatMapping -- flat signatures 0-12 flats
  * @property {string[]} sharpMapping -- sharp signatures 0-12 sharps
- * @extends music21.base.Music21Object
  * @example
  * var ks = new music21.key.KeySignature(-3); //E-flat major or c minor
  * var s = new music21.stream.Stream();
@@ -133,7 +116,6 @@ export class KeySignature extends base.Music21Object {
     /**
      * An Array of Altered Pitches in KeySignature order (i.e., for flats, Bb, Eb, etc.)
      *
-     * @type {music21.pitch.Pitch[]}
      * @readonly
      * @example
      * var ks = new music21.key.KeySignature(3)
@@ -214,8 +196,7 @@ export class KeySignature extends base.Music21Object {
     /**
      * Returns the accidental associated with a step in this key, or undefined if none.
      *
-     * @param {string} step - a valid step name such as "C","D", etc., but not "C#" etc.
-     * @returns {(music21.pitch.Accidental|undefined)}
+     * step - a valid step name such as "C","D", etc., but not "C#" etc.
      */
     accidentalByStep(step: string): pitch.Accidental|undefined {
         const aps = this.alteredPitches;
@@ -237,7 +218,6 @@ export class KeySignature extends base.Music21Object {
      *
      * Does not support inPlace unlike music21p v6.
      *
-     * @returns {music21.pitch.Pitch}
      * @example
      * var ks = new music21.key.KeySignature(-3)
      * var p1 = new music21.pitch.Pitch('B')
@@ -274,12 +254,11 @@ export class KeySignature extends base.Music21Object {
 /**
  * Create a Key object. Like a KeySignature but with ideas about Tonic, Dominant, etc.
  *
- * TODO: allow keyName to be a {@link music21.pitch.Pitch}
+ * TODO: allow keyName to be a music21.pitch.Pitch
  * TODO: Scale mixin.
  *
  * @class Key
  * @memberof music21.key
- * @extends music21.key.KeySignature
  * @param {string} keyName -- a pitch name representing the key (w/ "-" for flat)
  * @param {string} [mode] -- if not given then the CASE of the keyName will be used ("C" => "major", "c" => "minor")
  */
@@ -337,13 +316,13 @@ export class Key extends KeySignature {
     }
 
     /**
-     * returns a {@link music21.scale.MajorScale} or {@link music21.scale.MinorScale}
+     * returns a music21.scale.MajorScale or music21.scale.MinorScale
+     * or another similar scale
      * object from the pitch object.
      *
-     * @param {string|undefined} [scaleType=this.mode] - the type of scale, or the mode.
-     * @returns {Object} A music21.scale.Scale subclass.
+     * [scaleType=this.mode] - the type of scale, or the mode.
      */
-    getScale(scaleType=undefined) {
+    getScale(scaleType?: string): scale.ConcreteScale {
         if (scaleType === undefined) {
             scaleType = this.mode;
         }

--- a/src/key.ts
+++ b/src/key.ts
@@ -36,8 +36,6 @@ export function convertKeyStringToMusic21KeyString(textString: string): string {
 }
 
 /**
- * @class KeySignature
- * @memberof music21.key
  * @description Represents a key signature
  * @param {int} [sharps=0] -- the number of sharps (negative for flats)
  * @property {int} [sharps=0] -- number of sharps (negative for flats)
@@ -257,8 +255,6 @@ export class KeySignature extends base.Music21Object {
  * TODO: allow keyName to be a music21.pitch.Pitch
  * TODO: Scale mixin.
  *
- * @class Key
- * @memberof music21.key
  * @param {string} keyName -- a pitch name representing the key (w/ "-" for flat)
  * @param {string} [mode] -- if not given then the CASE of the keyName will be used ("C" => "major", "c" => "minor")
  */

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -246,8 +246,6 @@ export class BlackKey extends Key {
 /**
  * A Class representing a whole Keyboard full of keys.
  *
- * @class Keyboard
- * @memberof music21.keyboard
  * @property {number} whiteKeyWidth - default 23
  * @property {number} scaleFactor - default 1
  * @property {Object} keyObjects - a mapping of id to `music21.keyboard.Key` objects
@@ -609,7 +607,6 @@ export class Keyboard {
 /**
  * triggerToggleShow -- event for keyboard is shown or hidden.
  *
- * @function music21.keyboard.triggerToggleShow
  * @param {Event} [e]
  */
 export const triggerToggleShow = e => {

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -23,19 +23,15 @@ import * as stream from './stream';
  * This is possible because the system is deterministic and
  * will come to the same result for each part.  Opportunity
  * for making more efficient through this...
- *
- * @param {music21.stream.Score} score
- * @param {number} containerWidth
- * @returns {LayoutScore}
  */
 export function makeLayoutFromScore(
-    score,
-    containerWidth
-) {
+    score: stream.Score,
+    containerWidth: number,
+): LayoutScore {
     const parts = score.parts.stream();
     // console.log(parts);
     const numParts = parts.length;
-    const partZero = parts.get(0);
+    const partZero = parts.get(0) as stream.Part;
     const numMeasures = partZero.getElementsByClass('Measure').length;
 
     const measureWidths = partZero.getMeasureWidths();
@@ -107,7 +103,7 @@ export function makeLayoutFromScore(
             currentLeft = currentRight;
         }
         for (let pNum = 0; pNum < currentStaves.length; pNum++) {
-            currentStaves[pNum].append(parts.get(pNum).get(i));
+            currentStaves[pNum].append((parts.get(pNum) as stream.Part).get(i));
         }
     }
     for (let j = 0; j < currentStaves.length; j++) {
@@ -118,19 +114,12 @@ export function makeLayoutFromScore(
     return layoutScore;
 }
 
-/**
- * @extends music21.stream.Score
- * @property {number|undefined} measureStart
- * @property {number|undefined} measureEnd
- * @property {number|undefined} width
- * @property {number|undefined} height
- */
 export class LayoutScore extends stream.Score {
     static get className() { return 'music21.layout.LayoutScore'; }
 
     scoreLayout;
-    measureStart;
-    measureEnd;
+    measureStart: number;
+    measureEnd: number;
     protected _width: number;
     height: number;
     top: number;
@@ -141,11 +130,6 @@ export class LayoutScore extends stream.Score {
         this.scoreLayout = undefined;
         this.measureStart = undefined;
         this.measureEnd = undefined;
-        /**
-         *
-         * @type {number|undefined}
-         * @private
-         */
         this._width = undefined;
         this.height = undefined;
         this.top = 0;
@@ -182,21 +166,15 @@ export class LayoutScore extends stream.Score {
 
 /**
  * All music must currently be on page 1.
- *
- * @extends music21.stream.Score
- * @property {number|undefined} measureStart
- * @property {number|undefined} measureEnd
- * @property {number|undefined} systemStart
- * @property {number|undefined} systemEnd
  */
 export class Page extends stream.Score {
     static get className() { return 'music21.layout.Page'; }
 
     pageNumber: number;
-    measureStart;
-    measureEnd;
-    systemStart;
-    systemEnd;
+    measureStart: number;
+    measureEnd: number;
+    systemStart: number;
+    systemEnd: number;
     pageLayout;
     _width: number;
 
@@ -226,21 +204,14 @@ export class Page extends stream.Score {
 }
 
 /**
- * @extends music21.stream.Score
- * @property {number|undefined} measureStart
- * @property {number|undefined} measureEnd
- * @property {number|undefined} width
- * @property {number|undefined} height
- * @property {number|undefined} top
- * @property {number|undefined} left
  */
 export class System extends stream.Score {
     static get className() { return 'music21.layout.System'; }
 
     systemNumber: number;
     systemLayout;
-    measureStart;
-    measureEnd;
+    measureStart: number;
+    measureEnd: number;
     protected _width: number;
     height: number;
     top: number;
@@ -272,10 +243,6 @@ export class System extends stream.Score {
     }
 }
 
-/**
- * @extends music21.stream.Score
- *
- */
 export class Staff extends stream.Part {
     static get className() { return 'music21.layout.Staff'; }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -138,7 +138,7 @@ export {
     webmidi,
 };
 
-export const VERSION = '0.11.13';
+export const VERSION = '0.11.14';
 
 if (typeof window !== 'undefined') {
     (window as any).$ = $;

--- a/src/meter.ts
+++ b/src/meter.ts
@@ -4,16 +4,6 @@
  *
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
- *
- * meter module. See {@link music21.meter} namespace for details.
- * Meter and TimeSignature Classes (esp. {@link music21.meter.TimeSignature} ) and methods.
- *
- * @exports music21/meter
- *
- * @namespace music21.meter
- * @memberof music21
- * @requires music21/base
- * @requires music21/duration
  */
 import Vex from 'vexflow';
 
@@ -35,8 +25,6 @@ import { Music21Exception } from './exceptions21';
  * @property {int} [denominator=4]
  * @property {number[][]} beatGroups - groupings of beats; inner arrays are numerator, denominator
  * @property {string} ratioString - a string like "4/4"
- * @property {music21.duration.Duration} barDuration - a Duration object
- *     representing the expressed total length of the TimeSignature.
  */
 export class TimeSignature extends base.Music21Object {
     static get className() { return 'music21.meter.TimeSignature'; }
@@ -403,7 +391,7 @@ export class TimeSignature extends base.Music21Object {
     /**
      * Compute the Beat Group according to this time signature for VexFlow. For beaming.
      *
-     * @returns {Array<Vex.Flow.Fraction>} a list of numerator and denominator groups, for VexFlow
+     * returns a list of numerator and denominator groups, for VexFlow, as Vex.Flow.Fraction[]
      */
     vexflowBeatGroups(): Vex.Flow.Fraction[] {
         const tempBeatGroups = this.beatGroups;

--- a/src/miditools.ts
+++ b/src/miditools.ts
@@ -11,10 +11,6 @@
  *
  * Module that holds **music21j** tools for connecting with MIDI.js and somewhat with the
  * events from the Jazz plugin or the WebMIDI protocol.
- *
- *
- * @exports music21/miditools
- * @memberof music21
  */
 import * as $ from 'jquery';
 import * as MIDI from 'midicube';
@@ -43,7 +39,7 @@ export interface CallbackInterface {
 
 
 // expose midicube version of MIDI to the window for soundfonts to load.
-if (typeof window !== undefined) {
+if (typeof window !== 'undefined') {
     (<MIDIWindow> window).MIDI = MIDI;
 }
 
@@ -107,8 +103,6 @@ export const config = new _ConfigSingletonClass();
 
 
 /**
- * @class Event
- * @memberof music21.miditools
  * @param {number} t - timing information
  * @param {number} a - midi data 1 (N.B. a >> 4 = midiCommand )
  * @param {number} b - midi data 2
@@ -177,9 +171,6 @@ export class Event {
 
 /**
  * a mapping of soundfont text names to true, false, or "loading".
- *
- * @memberof music21.miditools
- * @type {Object}
  */
 export const loadedSoundfonts = {};
 
@@ -191,8 +182,6 @@ export const loadedSoundfonts = {};
  *
  *  Runs a setTimeout on itself.
  *  Calls miditools.sendOutChord
- *
- *  @memberof music21.miditools
  */
 export function clearOldChords() {
     // clear out notes that may be a chord...
@@ -314,12 +303,13 @@ export const sendToMIDIjs = (midiEvent: Event): void => {
  * Called after a soundfont has been loaded. The callback is better to be specified elsewhere
  * rather than overriding this important method.
  *
- * @memberof music21.miditools
- * @param {string} soundfont The name of the soundfont that was just loaded
- * @param {function} callback A function to be called after the soundfont is loaded.
+ * soundfont -- The name of the soundfont that was just loaded
+ * callback -- A function to be called after the soundfont is loaded.
  */
-export function postLoadCallback(soundfont: string,
-                                 callback?: (instrumentObj?: instrument.Instrument) => any) {
+export function postLoadCallback(
+    soundfont: string,
+    callback?: (instrumentObj?: instrument.Instrument) => any
+): void {
     // this should be bound to MIDI
     if (debug) {
         console.log('soundfont loaded about to execute callback.');
@@ -365,7 +355,6 @@ export function postLoadCallback(soundfont: string,
  * method to load soundfonts while waiting for other processes that need them
  * to load first.
  *
- * @memberof music21.miditools
  * @param {string} soundfont The name of the soundfont that was just loaded
  * @param {function} [callback] A function to be called after the soundfont is loaded.
  * @example

--- a/src/musicxml/m21ToXml.ts
+++ b/src/musicxml/m21ToXml.ts
@@ -1,6 +1,3 @@
-/**
- * @namespace music21.musicxml.m21ToXml
- */
 import * as clef from '../clef';
 import * as common from '../common';
 import {  // eslint-disable-line import/no-cycle
@@ -198,9 +195,6 @@ export class GeneralObjectExporter {
 
 const _musicxmlVersion = '3.0';
 
-/**
- * @memberOf music21.musicxml.m21ToXml
- */
 export class XMLExporterBase {
     doc: XMLDocument;
     xmlRoot;
@@ -362,9 +356,6 @@ export class XMLExporterBase {
 
 }
 
-/**
- * @extends music21.musicxml.m21ToXml.XMLExporterBase
- */
 export class ScoreExporter extends XMLExporterBase {
     stream: Score;
     xmIdentification = undefined;
@@ -490,9 +481,6 @@ export class ScoreExporter extends XMLExporterBase {
     // TODO(msc): contributorToXmlCreator
 }
 
-/**
- * @extends music21.musicxml.m21ToXml.XMLExporterBase
- */
 export class PartExporter extends XMLExporterBase {
     stream: Part;
     parent: ScoreExporter;
@@ -581,9 +569,6 @@ const _ignoreOnParseClasses = ['LayoutBase', 'Barline'];
 
 const divisionsPerQuarter = 32 * 3 * 3 * 5 * 7; // TODO(msc): create defaults.js
 
-/**
- * @extends music21.musicxml.m21ToXml.XMLExporterBase
- */
 export class MeasureExporter extends XMLExporterBase {
     stream: Measure;
     parent: PartExporter;
@@ -713,12 +698,8 @@ export class MeasureExporter extends XMLExporterBase {
 
     /**
      *
-     * @param {music21.note.GeneralNote} n
-     * @param noteIndexInChord
-     * @param chordParent
-     * @returns {Node}
      */
-    noteToXml(n: GeneralNote, { noteIndexInChord=0, chordParent=undefined }={}) {
+    noteToXml(n: GeneralNote, { noteIndexInChord=0, chordParent=undefined }={}): Node {
         const addChordTag = (noteIndexInChord !== 0);
         let chordOrN;
         if (chordParent === undefined) {

--- a/src/musicxml/xmlToM21.ts
+++ b/src/musicxml/xmlToM21.ts
@@ -138,11 +138,6 @@ export class ScoreParser {
     }
 }
 
-/**
- * @property {MeasureParser|undefined} lastMeasureParser
- * @property {music21.meter.TimeSignature|undefined} lastTimeSignature
- * @property {jQuery|undefined} $activeAttributes
- */
 export class PartParser {
     parent: ScoreParser;
     $mxPart;
@@ -152,25 +147,25 @@ export class PartParser {
     atSoundingPitch = true;
     staffReferenceList = [];
 
-    lastTimeSignature = undefined;
+    lastTimeSignature: meter.TimeSignature;
     lastMeasureWasShort = false;
     lastMeasureOffset = 0.0;
     lastClefs;
     activeTuplets = [undefined, undefined, undefined, undefined, undefined, undefined, undefined];
     maxStaves = 1;
     lastMeasureNumber = 0;
-    lastNumberSuffix = undefined;
+    lastNumberSuffix;
 
     multiMeasureRestsToCapture = 0;
-    activeMultimeasureRestSpanner = undefined;
+    activeMultimeasureRestSpanner;
 
-    activeInstrument = undefined;
+    activeInstrument;
     firstMeasureParsed = false;
-    $activeAttributes = undefined;
+    $activeAttributes: JQuery;
     lastDivisions = DEFAULTS.divisionsPerQuarter;
 
     appendToScoreAfterParse = true;
-    lastMeasureParser = undefined;
+    lastMeasureParser: MeasureParser;
 
     constructor($mxPart, $mxScorePart, parent=undefined) {
         this.parent = parent;
@@ -283,7 +278,7 @@ export class MeasureParser {
 
     $mxNoteList = [];
     $mxLyricList = [];
-    nLast = undefined;
+    nLast: note.GeneralNote;
     chordVoice = undefined;
     fullMeasureRest = false;
     restAndNoteCount = {
@@ -324,21 +319,13 @@ export class MeasureParser {
         // Note: <print> is handled separately...
     };
 
-    /**
-     *
-     * @param {jQuery} $mxMeasure
-     * @param {PartParser} [parent]
-     * @property {music21.note.GeneralNote|undefined} nLast
-     * @property {jQuery|undefined} $activeAttributes
-     */
-    constructor($mxMeasure, parent: PartParser = undefined) {
+    constructor($mxMeasure: JQuery, parent: PartParser = undefined) {
         this.$mxMeasure = $mxMeasure;
         this.parent = parent;
         this.stream = new stream.Measure();
 
         this.voiceIndices = new Set();
         this.staves = 1;
-        this.$activeAttributes = undefined;
         this.attributesAreInternal = true;
 
         if (parent !== undefined) {
@@ -608,12 +595,7 @@ export class MeasureParser {
     // xmlToTremolo
     // xmlOneSpanner
 
-    /**
-     *
-     * @param {jQuery} $mxNote
-     * @returns {music21.tie.Tie}
-     */
-    xmlToTie($mxNote) {
+    xmlToTie($mxNote: JQuery): tie.Tie {
         const t = new tie.Tie();
         const allTies = $mxNote.children('tie');
         if (allTies.length > 1) {
@@ -642,13 +624,7 @@ export class MeasureParser {
         }
     }
 
-    /**
-     *
-     * @param {jQuery} $mxLyric
-     * @param {music21.note.Lyric} [inputM21]
-     * @returns {*|music21.note.Lyric|undefined}
-     */
-    xmlToLyric($mxLyric, inputM21=undefined) {
+    xmlToLyric($mxLyric: JQuery, inputM21?: note.Lyric): note.Lyric {
         let l = inputM21;
         if (inputM21 === undefined) {
             l = new note.Lyric('');
@@ -660,15 +636,15 @@ export class MeasureParser {
         }
         let number = $mxLyric.attr('number');
         try {
-            number = parseInt(number);
-            l.number = number;
+            const num = parseInt(number);
+            l.number = num;
         } catch (exc) {
             l.number = 0;
             if (number !== undefined) {
-                l.identifier = number;
+                l.identifier = number.toString();
             }
         }
-        const identifier = $mxLyric.get('name');
+        const identifier: string = $mxLyric.attr('name');
         if (identifier !== undefined) {
             l.identifier = identifier;
         }

--- a/src/musicxml/xmlToM21.ts
+++ b/src/musicxml/xmlToM21.ts
@@ -634,7 +634,7 @@ export class MeasureParser {
         } catch (exc) {
             return undefined; // sometimes there are empty lyrics.
         }
-        let number = $mxLyric.attr('number');
+        const number = $mxLyric.attr('number');
         try {
             const num = parseInt(number);
             l.number = num;

--- a/src/note.ts
+++ b/src/note.ts
@@ -76,7 +76,6 @@ export const stemDirectionNames: string[] = [
 /**
  * Class for a single Lyric attached to a {@link GeneralNote}
  *
- * @class Lyric
  * @param {string} text - the text of the lyric
  * @param {number} number=1 - the lyric number
  * @param {string} syllabic=undefined - placement of the syllable
@@ -209,8 +208,6 @@ export class Lyric extends prebase.ProtoM21Object {
 /**
  * Superclass for all Note values
  *
- * @class GeneralNote
- * @memberof music21.note
  * @param {(number|undefined)} [ql=1.0] - quarterLength of the note
  * @property {boolean} [isChord=false] - is this a chord
  * @property {number} quarterLength - shortcut to `.duration.quarterLength`
@@ -385,7 +382,7 @@ export class GeneralNote extends base.Music21Object {
      * @param {base.Music21Object} [nextElement] - for determining
      *     the length to play in case of tied notes, etc.
      * @param {Object} [options] - other options (currently just
-     *     `{instrument: {@link music21.instrument.Instrument} }`)
+     *     `{instrument: music21.instrument.Instrument}` and channel[unused])
      * @returns {number} - delay time in milliseconds until the next element (may be ignored)
      */
     playMidi(
@@ -453,7 +450,7 @@ export class NotRest extends GeneralNote {
     /**
      * Returns a `Vex.Flow.StaveNote` that approximates this note.
      *
-     * @param {Object} [options={}] - `{clef: {@link music21.clef.Clef} }`
+     * @param {Object} [options={}] - `{clef: music21.clef.Clef}`
      * clef to set the stem direction of.
      */
     vexflowNote({ clef=undefined }={}): Vex.Flow.StaveNote {
@@ -525,9 +522,6 @@ export class NotRest extends GeneralNote {
  * things you can do with a `Note` object.
  *
  * Missing from music21p: `transpose(), fullName`.  Transpose cannot be added because of circular imports
- *
- * @class Note
- * @memberof music21.note
  */
 export class Note extends NotRest {
     static get className() { return 'music21.note.Note'; }
@@ -716,8 +710,6 @@ export class Note extends NotRest {
 /**
  * Represents a musical rest.
  *
- * @class Rest
- * @memberof music21.note
  * @param {number} [ql=1.0] - length in number of quarterNotes
  * @property {Boolean} [isNote=false]
  * @property {Boolean} [isRest=true]

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -5,18 +5,14 @@
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21, Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  *
- * pitch module.  See {@link music21.pitch} namespace
  * Pitch related objects and methods
- *
- * @exports music21/pitch
- * @namespace music21.pitch
- * @memberof music21
- * @requires music21/prebase
  */
 import { Music21Exception } from './exceptions21';
 
 import * as prebase from './prebase';
 import * as common from './common';
+
+import type * as clef from './clef';
 
 
 interface UpdateAccidentalDisplayParams {
@@ -283,9 +279,9 @@ export const midiToName = [
 ];
 
 /**
- * Pitch objects are found in {@link music21.note.Note} objects, and many other places.
+ * Pitch objects are found in music21.note.Note objects, and many other places.
  *
- * They do not have a {@link music21.duration.Duration} associated with them, so they
+ * They do not have a music21.duration.Duration associated with them, so they
  * cannot be placed inside music21.stream.Stream objects.
  *
  * Valid pitch name formats are
@@ -995,12 +991,11 @@ export class Pitch extends prebase.ProtoM21Object {
      *
      * if clefObj is undefined, then the clef is treated as TrebleClef.
      *
-     * @param {music21.clef.Clef} [clefObj] - the active {@link music21.clef.Clef} object
-     * @returns {string} - representation in vexflow
+     * [clefObj] - the active music21.clef.Clef object
      */
-    vexflowName(clefObj=undefined) {
+    vexflowName(clefObj?: clef.Clef): string {
         // returns a vexflow Key name for this pitch.
-        let tempPitch = this;
+        let tempPitch: Pitch = this;
         if (clefObj !== undefined) {
             try {
                 tempPitch = clefObj.convertPitchToTreble(this);

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -29,8 +29,6 @@ interface UpdateAccidentalDisplayParams {
 
 
 /**
- * @class Accidental
- * @memberof music21.pitch
  * @param {string|number} accName - an accidental name
  * @property {number} alter
  * @property {string} displayType
@@ -294,8 +292,6 @@ export const midiToName = [
  *     adjust according to context. If you do not like this behavior, give an octave always.
  * - Microtones are not supported in music21j (they are in music21p)
  *
- * @class Pitch
- * @memberof music21.pitch
  * @param {string|number} pn - name of the pitch, with or without octave, see above.
  * @property {Accidental|undefined} accidental - link to an accidental
  * @property {number} diatonicNoteNum - diatonic number of the pitch,

--- a/src/prebase.ts
+++ b/src/prebase.ts
@@ -1,11 +1,8 @@
 /**
  * module for things that all music21-created objects, not just objects that can live in
- * Stream.elements should inherit. See the {@link music21.prebase} namespace.
+ * Stream.elements should inherit.
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  *
- * @exports music21/prebase
- * @namespace music21.prebase
- * @memberof music21
  */
 
 declare interface ProtoM21ObjectConstructorInterface extends Function {
@@ -20,12 +17,10 @@ declare interface Constructable<T> {
  * Class for pseudo-m21 objects to inherit from. The most important attributes that nearly
  * everything in music21 should inherit from are given below.
  *
- * @class ProtoM21Object
- * @memberof music21.prebase
  * @property {Array<string>} classes - An Array of strings of classes
  * that the object belongs to (default ['ProtoM21Object'])
  * @property {boolean} isProtoM21Object - Does this object descend
- * from {@link music21.prebase.ProtoM21Object}: obviously true.
+ * from music21.prebase.ProtoM21Object: obviously true.
  * @property {boolean} isMusic21Object - Does this object descend
  * from Music21Object; default false.
  */

--- a/src/renderOptions.ts
+++ b/src/renderOptions.ts
@@ -7,12 +7,8 @@
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  *
- * renderOptions module, see {@link music21.renderOptions}
  * Options for rendering a stream
  *
- * @exports music21/renderOptions
- * @namespace music21.renderOptions
- * @memberof music21
  */
 
 interface EventInterface {
@@ -31,8 +27,6 @@ interface ScaleFactor {
  * An object that contains information on rendering the current stream
  *
  * Found on every Stream as `.renderOptions`
- *
- * @memberof music21.renderOptions
  */
 export class RenderOptions {
     displayClef: boolean = true;

--- a/src/roman.ts
+++ b/src/roman.ts
@@ -7,16 +7,6 @@
  *
  * Roman numeral module. See  namespace
  * music21.roman -- namespace for dealing with RomanNumeral analysis.
- *
- * @exports music21/roman
- * @memberof music21
- * @requires music21/chord
- * @requires music21/common
- * @requires music21/figuredBass
- * @requires music21/harmony
- * @requires music21/key
- * @requires music21/pitch
- * @requires music21/interval
  */
 import { Music21Exception } from './exceptions21';
 
@@ -199,11 +189,11 @@ export const romanToNumber = [undefined, 'i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii
  *
  * @class RomanNumeral
  * @memberof music21.roman
- * @param {string} figure - the roman numeral as a string, e.g., 'IV', 'viio', 'V7'
- * @param {string|music21.key.Key} [keyStr='C']
- * @property {Array<music21.pitch.Pitch>} scale - (readonly) returns the scale
+ * figure - the roman numeral as a string, e.g., 'IV', 'viio', 'V7'
+ * [keyStr='C']
+ * @property scale - (readonly) returns the scale
  *     associated with the roman numeral
- * @property {music21.key.Key} key - the key associated with the
+ * @property key - the key associated with the
  *     RomanNumeral (not allowed to be undefined yet)
  * @property {string} figure - the figure as passed in
  * @property {string} degreeName - the name associated with the scale degree,
@@ -211,16 +201,8 @@ export const romanToNumber = [undefined, 'i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii
  *     "subtonic" appropriately
  * @property {int} scaleDegree
  * @property {string|undefined} impliedQuality - "major", "minor", "diminished", "augmented"
- * @property {music21.roman.RomanNumeral|undefined} secondaryRomanNumeral
- * @property {music21.key.Key|undefined} secondaryRomanNumeralKey
  * @property {string|undefined} frontAlterationString
- * @property {music21.interval.Interval|undefined} frontAlterationTransposeInterval
- * @property {music21.pitch.Accidental|undefined} frontAlterationAccidental
  * @property {string|undefined} romanNumeralAlone
- * @property {scale.Scale|boolean|undefined} impliedScale
- * @property {music21.interval.Interval|undefined} scaleOffset
- * @property {Array<music21.pitch.Pitch>} pitches - RomanNumerals
- *     are Chord objects, so .pitches will work for them also.
  */
 export class RomanNumeral extends harmony.Harmony {
     static get className() { return 'music21.roman.RomanNumeral'; }
@@ -241,8 +223,8 @@ export class RomanNumeral extends harmony.Harmony {
     romanNumeralAlone;
     quality;
     impliedQuality;
-    impliedScale;
-    scaleOffset;
+    impliedScale: key.Key;
+    scaleOffset: interval.Interval;
     useImpliedScale: boolean;
     bracketedAlterations;
     omittedSteps;
@@ -337,7 +319,8 @@ export class RomanNumeral extends harmony.Harmony {
         );
 
         if (workingFigure === 'Cad64') {
-            if (useScale.mode === 'minor') {
+            // useScale might be a Scale, not Key. TODO: NO!
+            if ((useScale as key.Key).mode === 'minor') {
                 workingFigure = 'i64';
             } else {
                 workingFigure = 'I64';
@@ -562,10 +545,10 @@ export class RomanNumeral extends harmony.Harmony {
         }
         if (keyOrScale === undefined) {
             this.useImpliedScale = true;
-            this.impliedScale = new scale.MajorScale('C');
+            this.impliedScale = new key.Key('C');
         } else {
             this.useImpliedScale = false;
-            this.impliedScale = false;
+            this.impliedScale = undefined;
         }
         if (this._parsingComplete) {
             this._updatePitches();

--- a/src/roman.ts
+++ b/src/roman.ts
@@ -95,7 +95,6 @@ export const functionalityScores = {
  *
  * N.B. this is NOT where abbreviations get expanded
  *
- * @memberof music21.roman
  * @param  {string} shorthand string of a figure w/o roman to parse
  * @return {Array<string>}           array of shorthands
  */
@@ -131,7 +130,6 @@ export function expandShortHand(shorthand) {
  * correctSuffixForChordQuality - Correct a given inversionString suffix given a
  *     chord of various qualities.
  *
- * @memberof music21.roman
  * @param  {chord.Chord} chordObj
  * @param  {string} inversionString a string like '6' to fix.
  * @return {string}           corrected inversionString
@@ -176,7 +174,6 @@ export function correctSuffixForChordQuality(
 /**
  * maps an index number to a roman numeral in lowercase
  *
- * @memberof music21.roman
  * @example
  * music21.roman.romanToNumber[4]
  * // 'iv'
@@ -187,8 +184,6 @@ export const romanToNumber = [undefined, 'i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii
  * Represents a RomanNumeral.  By default, capital Roman Numerals are
  * major chords; lowercase are minor.
  *
- * @class RomanNumeral
- * @memberof music21.roman
  * figure - the roman numeral as a string, e.g., 'IV', 'viio', 'V7'
  * [keyStr='C']
  * @property scale - (readonly) returns the scale

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -1,8 +1,4 @@
 /**
- * Scale module. See {@link music21.scale} namespace
- * @module music21/scale
- */
-/**
  * music21j -- Javascript reimplementation of Core music21p features.
  * music21/scale -- Scales
  *
@@ -10,17 +6,6 @@
  *
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
- *
- *
- *
- * Scale namespace.  Right now only supports very simple scales.
- *
- * @namespace music21.scale
- * @requires music21.base
- * @requires music21.common
- * @requires music21.debug
- * @requires music21.interval
- * @requires music21.pitch
  */
 import { Music21Exception } from './exceptions21';
 import { debug } from './debug';
@@ -37,13 +22,10 @@ import * as note from './note';
 // const DIRECTION_DESCENDING = 'descending';
 // const DIRECTION_ASCENDING = 'ascending';
 
-export
 /**
  * A generalized Scale object.
- *
- * @memberOf music21.scale
  */
-class Scale extends base.Music21Object {
+export class Scale extends base.Music21Object {
     static get className() { return 'music21.scale.Scale'; }
 
     type: string = 'Scale';
@@ -71,13 +53,10 @@ class Scale extends base.Music21Object {
     }
 }
 
-export
 /**
  * An Abstract Scale
- *
- * @memberOf music21.scale
  */
-class AbstractScale extends Scale {
+export class AbstractScale extends Scale {
     static get className() { return 'music21.scale.AbstractScale'; }
 
     protected _net: interval.Interval[] = [];
@@ -228,10 +207,6 @@ class AbstractScale extends Scale {
     }
 }
 
-/**
- * @memberOf music21.scale
- *
- */
 export class AbstractDiatonicScale extends AbstractScale {
     static get className() { return 'music21.scale.AbstractDiatonicScale'; }
 
@@ -278,10 +253,6 @@ export class AbstractDiatonicScale extends AbstractScale {
     }
 }
 
-/**
- * @memberOf music21.scale
- *
- */
 export class AbstractHarmonicMinorScale extends AbstractScale {
     static get className() { return 'music21.scale.AbstractHarmonicMinorScale'; }
 
@@ -303,9 +274,6 @@ export class AbstractHarmonicMinorScale extends AbstractScale {
 
 // temporary, until bidirectional scales are created
 // no need for descending, since minor takes care of that.
-/**
- * @memberOf music21.scale
- */
 export class AbstractAscendingMelodicMinorScale extends AbstractScale {
     static get className() { return 'music21.scale.AbstractAscendingMelodicMinorScale'; }
 
@@ -325,9 +293,6 @@ export class AbstractAscendingMelodicMinorScale extends AbstractScale {
     }
 }
 
-/**
- * @memberOf music21.scale
- */
 export class ConcreteScale extends Scale {
     static get className() { return 'music21.scale.ConcreteScale'; }
 
@@ -407,9 +372,6 @@ export class ConcreteScale extends Scale {
     }
 }
 
-/**
- * @memberOf music21.scale
- */
 export class DiatonicScale extends ConcreteScale {
     static get className() { return 'music21.scale.DiatonicScale'; }
 
@@ -420,9 +382,6 @@ export class DiatonicScale extends ConcreteScale {
     }
 }
 
-/**
- * @memberOf music21.scale
- */
 export class MajorScale extends DiatonicScale {
     static get className() { return 'music21.scale.MajorScale'; }
 
@@ -434,9 +393,6 @@ export class MajorScale extends DiatonicScale {
 }
 
 
-/**
- * @memberOf music21.scale
- */
 export class MinorScale extends DiatonicScale {
     static get className() { return 'music21.scale.MinorScale'; }
 
@@ -447,9 +403,6 @@ export class MinorScale extends DiatonicScale {
     }
 }
 
-/**
- * @memberOf music21.scale
- */
 export class HarmonicMinorScale extends ConcreteScale {
     static get className() { return 'music21.scale.HarmonicMinorScale'; }
 
@@ -460,9 +413,6 @@ export class HarmonicMinorScale extends ConcreteScale {
     }
 }
 
-/**
- * @memberOf music21.scale
- */
 export class AscendingMelodicMinorScale extends ConcreteScale {
     static get className() { return 'music21.scale.AscendingMelodicMinorScale'; }
 
@@ -474,16 +424,9 @@ export class AscendingMelodicMinorScale extends ConcreteScale {
 }
 
 /**
- * Function, not class
- *
- * @memberOf music21.scale
- * @function music21.scale.SimpleDiatonicScale
- * @param {pitch.Pitch} [tonic]
- * @param {Array<string>} scaleSteps - an array of diatonic prefixes,
- *     generally 'M' (major) or 'm' (minor) describing the seconds.
- * @returns {Array<pitch.Pitch>} an octave of scale objects.
+ * Function, not class.  DEPRECATED: to be removed.
  */
-export function SimpleDiatonicScale(tonic, scaleSteps) {
+export function SimpleDiatonicScale(tonic: pitch.Pitch, scaleSteps: string[]): pitch.Pitch[] {
     if (tonic === undefined) {
         tonic = new pitch.Pitch('C4');
     } else if (!(tonic instanceof pitch.Pitch)) {
@@ -513,12 +456,8 @@ export function SimpleDiatonicScale(tonic, scaleSteps) {
 }
 
 /**
+ * Function, not class.  DEPRECATED: to be removed.
  * One octave of a major scale
- *
- * @memberOf music21.scale
- * @function music21.scale.ScaleSimpleMajor
- * @param {pitch.Pitch} tonic
- * @returns {Array<pitch.Pitch>} an octave of scale objects.
  */
 export function ScaleSimpleMajor(tonic: pitch.Pitch): pitch.Pitch[] {
     const scaleSteps = ['M', 'M', 'm', 'M', 'M', 'M', 'm'];
@@ -526,15 +465,11 @@ export function ScaleSimpleMajor(tonic: pitch.Pitch): pitch.Pitch[] {
 }
 
 /**
+ * Function, not class.  DEPRECATED: to be removed.
  * One octave of a minor scale
- *
- * @memberOf music21.scale
- * @function music21.scale.ScaleSimpleMinor
- * @param {pitch.Pitch} tonic
- * @param {string} [minorType='natural'] - 'harmonic', 'harmonic-minor',
+ * [minorType='natural'] - 'harmonic', 'harmonic-minor',
  *     'melodic', 'melodic-minor', 'melodic-minor-ascending',
  *     'melodic-ascending' or other (=natural/melodic-descending)
- * @returns {Array<pitch.Pitch>} an octave of scale objects.
  */
 export function ScaleSimpleMinor(tonic, minorType) {
     const scaleSteps = ['M', 'm', 'M', 'M', 'm', 'M', 'M'];

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -1,12 +1,8 @@
 /**
- * Objects for keeping track of relationships among Music21Objects. See {@link music21.sites} namespace
+ * Objects for keeping track of relationships among Music21Objects.
  *
- * Copyright 2017-2019, Michael Scott Asato Cuthbert
+ * Copyright (c) 2017-2021, Michael Scott Asato Cuthbert
  * License: BSD
- *
- * @namespace music21.sites
- * @memberof music21
- * @requires music21/common
  */
 
 import * as common from './common';
@@ -46,12 +42,7 @@ const _singletonCounter = new common.SingletonCounter();
 
 const GLOBAL_SITE_STATE_DICT = new WeakMap();
 
-/**
- * @memberOf music21.sites
- * @param {*} obj
- * @returns {number|string}
- */
-export function getId(obj) {
+export function getId(obj: any): number|string {
     if (!GLOBAL_SITE_STATE_DICT.has(obj)) {
         const newId = _singletonCounter.call();
         GLOBAL_SITE_STATE_DICT.set(obj, newId);
@@ -59,9 +50,6 @@ export function getId(obj) {
     return GLOBAL_SITE_STATE_DICT.get(obj);
 }
 
-/**
- * @memberOf music21.sites
- */
 export class Sites {
     siteDict;
     protected _siteIndex: number = 0;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -771,7 +771,7 @@ export class Stream extends base.Music21Object {
         restoreActiveSites=true,
         classFilter=undefined,
         skipSelf=true,
-    }={}) {
+    }={}): iterator.RecursiveIterator {
         const includeSelf = !skipSelf;
         const ri = new iterator.RecursiveIterator(
             this,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -2843,9 +2843,6 @@ export class Measure extends Stream {
 
 /**
  * Part -- specialized to handle Measures inside it
- *
- * @class Part
- * @memberof music21.stream
  */
 export class Part extends Stream {
     static get className() { return 'music21.stream.Part'; }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -7,29 +7,17 @@
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21 (=music21p), Copyright (c) 2006-21, Michael Scott Asato Cuthbert
  *
- * powerful stream module, See {@link music21.stream} namespace
- * @exports music21/stream
+ * powerful stream module, See music21.stream namespace
  *
  * Streams are powerful music21 objects that hold Music21Object collections,
- * such as {@link music21.note.Note} or music21.chord.Chord objects.
+ * such as music21.note.Note or music21.chord.Chord objects.
  *
  * Understanding the {@link Stream} object is of fundamental
  * importance for using music21.  Definitely read the music21(python) tutorial
  * on using Streams before proceeding
  *
- * @namespace music21.stream
- * @memberof music21
- * @requires music21/base
- * @requires music21/renderOptions
- * @requires music21/clef
- * @requires music21/vfShow
- * @requires music21/duration
- * @requires music21/common
- * @requires music21/meter
- * @requires music21/pitch
- * @requires jQuery
- *
  */
+
 import * as $ from 'jquery';
 import * as MIDI from 'midicube';
 import Vex from 'vexflow';
@@ -102,31 +90,21 @@ interface MakeAccidentalsParams {
  * @property {number} length - (readonly) the number of elements in the stream.
  * @property {Duration} duration - the total duration of the stream's elements
  * @property {number} highestTime -- the highest time point in the stream's elements
- * @property {music21.clef.Clef} clef - the clef for the Stream (if there is
- *     one; if there are multiple, then the first clef)
- * @property {music21.meter.TimeSignature} timeSignature - the first TimeSignature of the Stream
- * @property {music21.key.KeySignature} keySignature - the first KeySignature for the Stream
  * @property {renderOptions.RenderOptions} renderOptions - an object
  *     specifying how to render the stream
  * @property {Stream} flat - (readonly) a flattened representation of the Stream
  * @property {StreamIterator} notes - (readonly) the stream with
- *     only {@link music21.note.Note} and music21.chord.Chord objects included
+ *     only note.NotRest (music21.note.Note and music21.chord.Chord) objects included
  * @property {StreamIterator} notesAndRests - (readonly) like notes but
- *     also with {@link music21.note.Rest} objects included
+ *     also with music21.note.Rest objects included
  * @property {StreamIterator} parts - (readonly) a filter on the Stream
  *     to just get the parts (NON-recursive)
  * @property {StreamIterator} measures - (readonly) a filter on the
  *     Stream to just get the measures (NON-recursive)
  * @property {number} tempo - tempo in beats per minute (will become more
  *     sophisticated later, but for now the whole stream has one tempo
- * @property {music21.instrument.Instrument|undefined} instrument - an
- *     instrument object associated with the stream (can be set with a
- *     string also, but will return an `Instrument` object)
  * @property {boolean} autoBeam - whether the notes should be beamed automatically
  *    or not (will be moved to `renderOptions` soon)
- * @property {Vex.Flow.Stave|undefined} activeVFStave - the current Stave object for the Stream
- * @property {music21.vfShow.Renderer|undefined} activeVFRenderer - the current
- *     vfShow.Renderer object for the Stream
  * @property {int} [staffLines=5] - number of staff lines
  * @property {function|undefined} changedCallbackFunction - function to
  *     call when the Stream changes through a standard interface
@@ -160,9 +138,18 @@ export class Stream extends base.Music21Object {
     // TODO(msc): _mutable -- experimental
 
     // music21j specific attributes NOT to remove:
+
+    /**
+     * the current Stave object for the Stream
+     */
     activeVFStave: Vex.Flow.Stave = undefined;
+
+    /**
+     * the current vfShow.Renderer object for the Stream
+     */
     activeVFRenderer: vfShow.Renderer = undefined;
     changedCallbackFunction: Function = undefined; // for editable svg objects
+
     /**
      * A function bound to the current stream that
      * will change the stream. Used in editableAccidentalDOM, among other places.
@@ -485,7 +472,10 @@ export class Stream extends base.Music21Object {
 
 
     /**
-     * Note that .instrument will never return a string, but Typescript requires
+     * The instrument object (NOT stored in the stream!) -- this is a difference from
+     * music21p and expect this to change soon.
+     *
+     * Note that .instrument will never return a string, but Typescript <= 4 requires
      * that getter and setter are the same.
      */
     get instrument(): instrument.Instrument|string {
@@ -1188,7 +1178,7 @@ export class Stream extends base.Music21Object {
      * @param {Object} [options]
      * @returns {Stream}
      */
-    makeMeasures(options) {
+    makeMeasures(options?) {
         const params = {
             meterStream: undefined,
             refStreamOrTimeRange: undefined,
@@ -1840,26 +1830,17 @@ export class Stream extends base.Music21Object {
 
 
     /**
-     * Uses {@link music21.vfShow.Renderer} to render Vexflow onto an
+     * Uses music21.vfShow.Renderer to render Vexflow onto an
      * existing canvas or SVG object.
      *
      * Runs `this.setRenderInteraction` on the canvas.
      *
      * Will be moved to vfShow eventually when converter objects are enabled...maybe.
      *
-     * @param {jQuery|HTMLElement} $canvasOrSVG - a canvas or the div surrounding an SVG object
-     * @returns {music21.vfShow.Renderer}
+     * Takes in a canvas or the div surrounding an SVG object
      */
-    renderVexflow($canvasOrSVG) {
-        /**
-         * @type {HTMLElement|undefined}
-         */
-        let canvasOrSVG;
-        if ($canvasOrSVG instanceof $) {
-            canvasOrSVG = $canvasOrSVG[0];
-        } else {
-            canvasOrSVG = $canvasOrSVG;
-        }
+    renderVexflow(where?: JQuery|HTMLElement): vfShow.Renderer {
+        const canvasOrSVG = common.coerceHTMLElement(where);
         const DOMContains = document.body.contains(canvasOrSVG);
         if (!DOMContains) {
             // temporarily add to DOM so Firefox can measure it...
@@ -2282,22 +2263,7 @@ export class Stream extends base.Music21Object {
         height: number|string = undefined,
         elementType: string = 'svg'
     ): HTMLElement {
-        // noinspection JSMismatchedCollectionQueryUpdate
-        let $appendElement: JQuery;
-        if (appendElement instanceof $) {
-            $appendElement = <JQuery><any> appendElement;
-        } else {
-            $appendElement = $(appendElement);
-        }
-
-        //      if (width === undefined && this.renderOptions.maxSystemWidth === undefined) {
-        //      var $bodyElement = bodyElement;
-        //      if (!(bodyElement instanceof $) {
-        //      $bodyElement = $(bodyElement);
-        //      }
-        //      width = $bodyElement.width();
-        //      };
-
+        const $appendElement = common.coerceJQuery(appendElement);
         const $svgOrCanvasBlock = this.createDOM(width, height, elementType);
         $appendElement.append($svgOrCanvasBlock);
         return $svgOrCanvasBlock[0];
@@ -2315,22 +2281,12 @@ export class Stream extends base.Music21Object {
      * @returns {JQuery} the svg
      */
     replaceDOM(
-        where,
+        where?: JQuery|HTMLElement,
         preserveSvgSize: boolean=false,
         elementType: string='svg'
     ): JQuery {
-        // if called with no where, replaces all the svg elements on the page...
-        if (where === undefined) {
-            where = document.body;
-        }
-        let $where;
-        if (!(where instanceof $)) {
-            $where = $(where);
-        } else {
-            $where = where;
-            // where = $where[0];
-        }
         let $oldSVGOrCanvas;
+        const $where = common.coerceJQuery(where);
 
         if ($where.hasClass('streamHolding')) {
             $oldSVGOrCanvas = $where;
@@ -2373,40 +2329,24 @@ export class Stream extends base.Music21Object {
      *    - 'reflow' (string; only on event.resize)
      *    - customFunction (will receive event as a first variable; should set up a way to
      *                    find the original stream; var s = this; var f = function () { s...}
-     *                   )
-     *
-     * @param {JQuery|HTMLElement} canvasOrDiv - canvas or the Div surrounding it.
-     * @returns {this}
      */
-    setRenderInteraction(canvasOrDiv: JQuery|HTMLElement) {
-        let $svg;
-        if (canvasOrDiv === undefined) {
-            return this;
-        } else if (!(canvasOrDiv instanceof $)) {
-            $svg = $(canvasOrDiv);
-        } else {
-            $svg = <JQuery> canvasOrDiv;
-        }
+    setRenderInteraction(where: JQuery|HTMLElement): this {
+        const $svg = common.coerceJQuery(where);
         const playFunc = () => {
             this.playStream();
         };
 
         for (const [eventType, eventFunction] of Object.entries(this.renderOptions.events)) {
             $svg.off(eventType);
-            if (
-                typeof eventFunction === 'string'
-                && eventFunction === 'play'
-            ) {
+            if (eventFunction === 'play') {
                 $svg.on(eventType, playFunc);
             } else if (
-                typeof eventFunction === 'string'
-                && eventType === 'resize'
+                eventType === 'resize'
                 && eventFunction === 'reflow'
             ) {
                 this.windowReflowStart($svg);
-            } else if (eventFunction !== undefined) {
-                const eventFunctionTyped = <Function><any> eventFunction;
-                $svg.on(eventType, eventFunctionTyped);
+            } else if (eventFunction instanceof Function) {
+                $svg.on(eventType, eventFunction);
             }
         }
         return this;
@@ -2415,10 +2355,8 @@ export class Stream extends base.Music21Object {
     /**
      *
      * Recursively search downward for the closest storedVexflowStave...
-     *
-     * @returns {Vex.Flow.Stave|undefined}
      */
-    recursiveGetStoredVexflowStave() {
+    recursiveGetStoredVexflowStave(): Vex.Flow.Stave|undefined {
         const storedVexflowStave = this.storedVexflowStave;
         if (storedVexflowStave === undefined) {
             if (this.isFlat) {
@@ -2455,9 +2393,9 @@ export class Stream extends base.Music21Object {
          */
         let xClick: number;
         let yClick: number;
-        if ((e instanceof MouseEvent || e instanceof $.Event)
-                && (e as MouseEvent).pageX !== undefined
+        if ((e as MouseEvent).pageX !== undefined
                 && (e as MouseEvent).pageY !== undefined) {
+            // MouseEvent or JQuery.MouseEventBase without instanceof checking.
             xClick = (e as MouseEvent).pageX;
             yClick = (e as MouseEvent).pageY;
         } else if (typeof TouchEvent !== 'undefined' && e instanceof TouchEvent) {
@@ -2471,7 +2409,7 @@ export class Stream extends base.Music21Object {
                 + document.body.scrollTop
                 + document.documentElement.scrollTop;
         } else {
-            console.error(`what are you? ${typeof e}`);
+            // older MouseEvent such as IE 8 -- unknown support in Firefox
             xClick
                 = (e as MouseEvent).clientX
                 + document.body.scrollLeft
@@ -2495,7 +2433,7 @@ export class Stream extends base.Music21Object {
      *
      */
     getScaledXYforDOM(
-        svg: HTMLElement|SVGElement|JQuery<HTMLElement>,
+        svg: HTMLElement|SVGElement|JQuery,
         e: MouseEvent|TouchEvent|JQuery.MouseEventBase
     ): [number, number] {
         const [xPx, yPx] = this.getUnscaledXYforDOM(svg, e);
@@ -2636,11 +2574,9 @@ export class Stream extends base.Music21Object {
      *
      * Return a list of [diatonicNoteNum, closestXNote]
      * for an event (e) called on the svg (svg)
-     *
-     * @returns {Array} [diatonicNoteNum, closestXNote]
      */
     findNoteForClick(
-        svg?: HTMLElement|SVGElement|JQuery<HTMLElement>,
+        svg?: HTMLElement|SVGElement|JQuery,
         e?: MouseEvent|TouchEvent|JQuery.MouseEventBase,
         x?: number,
         y?: number,
@@ -2656,18 +2592,13 @@ export class Stream extends base.Music21Object {
 
     /**
      * Change the pitch of a note given that it has been clicked and then
-     * call changedCallbackFunction
-     *
-     * @param {number} clickedDiatonicNoteNum
-     * @param {music21.note.Note} foundNote
-     * @param {SVGElement|HTMLElement} svg
-     * @returns {*} output of changedCallbackFunction
+     * call changedCallbackFunction and return it
      */
     noteChanged(
         clickedDiatonicNoteNum: number,
         foundNote: note.Note,
         svg: SVGElement|HTMLElement
-    ) {
+    ): any {
         const n = foundNote;
         const p = new pitch.Pitch('C');
         p.diatonicNoteNum = clickedDiatonicNoteNum;

--- a/src/stream/filters.ts
+++ b/src/stream/filters.ts
@@ -1,4 +1,5 @@
 import { Music21Exception } from '../exceptions21';
+import {Music21Object} from '../base';
 
 // noinspection JSUnusedGlobalSymbols
 export class FilterException extends Music21Exception {}
@@ -82,14 +83,17 @@ export class ClassFilter extends StreamFilter {
         return 'getElementsByClass';
     }
 
-    classList: string[];
+    classList: string[]|(typeof Music21Object)[];
 
-    constructor(classList: string|string[] =[]) {
+    constructor(classList: string|string[]|typeof Music21Object|(typeof Music21Object)[] =[]) {
         super();
+        let classListArray: string[]|typeof Music21Object[];
         if (!Array.isArray(classList)) {
-            classList = [classList];
+            classListArray = <string[]|(typeof Music21Object)[]> [classList];
+        } else {
+            classListArray = classList;
         }
-        this.classList = classList;
+        this.classList = classListArray;
     }
     // TODO: __eq__
 

--- a/src/stream/filters.ts
+++ b/src/stream/filters.ts
@@ -7,9 +7,6 @@ class _StopIteration {}
 
 export const StopIterationSingleton = new _StopIteration();
 
-/**
- * @memberof music21.stream.filters
- */
 export class StreamFilter {
     static get derivationStr() {
         return 'streamFilter';

--- a/src/stream/iterator.ts
+++ b/src/stream/iterator.ts
@@ -207,7 +207,7 @@ class _StreamIteratorBase<T = Music21Object> {
     //
     // }
 
-    getElementsByClass(classFilterList) {
+    getElementsByClass(classFilterList: string|string[]|typeof Music21Object|(typeof Music21Object)[]) {
         return this.addFilter(new filters.ClassFilter(classFilterList));
     }
 
@@ -497,4 +497,24 @@ export class RecursiveIterator<T = Music21Object> extends _StreamIteratorBase<T>
         }
     }
     // TODO(msc): getElementsByOffsetInHierarchy
+
+
+    // until we can figure out how to do this in pure typescript:
+    get notes() {
+        return super.notes as RecursiveIterator<NotRest>;
+    }
+
+    get notesAndRests() {
+        return super.notesAndRests as RecursiveIterator<GeneralNote>;
+    }
+
+    get parts() {
+        return super.parts as RecursiveIterator<Part>;
+    }
+
+    get voices() {
+        return super.voices as RecursiveIterator<Voice>;
+    }
+
+
 }

--- a/src/tie.ts
+++ b/src/tie.ts
@@ -10,30 +10,13 @@
 import * as prebase from './prebase';
 import { Music21Exception } from './exceptions21';
 
-/**
- * Simple tie module {@link music21.tie} namespace
- *
- * @exports music21/tie
- */
-
-/**
- * Tie namespace, just has the {@link music21.tie.Tie} object
- *
- * @namespace music21.tie
- * @memberof music21
- * @requires music21/prebase
- */
-
 const VALID_TIE_TYPES = ['start', 'stop', 'continue', 'let-ring', 'continue-let-ring'];
 
 /**
- * Tie class. Found in {@link music21.note.GeneralNote} `.tie`.
+ * Tie class. Found in music21.note.GeneralNote `.tie`.
  *
  * Does not support advanced music21p values `.to` and `.from`
  *
- * @class Tie
- * @memberof music21.tie
- * @extends music21.prebase.ProtoM21Object
  * @param {string} type - 'start', 'stop', 'continue', or 'let-ring'
  * @property {string} type - the tie type
  * @property {string} style - only supports 'normal' for now.
@@ -47,7 +30,7 @@ export class Tie extends prebase.ProtoM21Object {
     style: string = 'normal';
     placement: string;
 
-    constructor(type='start') {
+    constructor(type: string = 'start') {
         super();
         this.type = type;
     }

--- a/src/tinyNotation.ts
+++ b/src/tinyNotation.ts
@@ -60,7 +60,7 @@ const regularExpressions: { [k: string]: RegExp } = {
  *
  * * textIn - a valid tinyNotation string
  *
- * * returns {music21.stream.Part|music21.stream.Measure} - a Stream or Part object (if multiple measures)
+ * * returns {music21.stream.Part|music21.stream.Score} - a Part object or Score (if multiple parts)
  *
  * @example
  * var t = "3/4 c4 B8 c d4 e2.";
@@ -68,7 +68,7 @@ const regularExpressions: { [k: string]: RegExp } = {
  * p.duration.quarterLength;
  * // 6.0
  */
-export function TinyNotation(textIn: string): stream.Part|stream.Measure|stream.Score {
+export function TinyNotation(textIn: string): stream.Part|stream.Score {
     textIn = textIn.trim();
     const tokens: string[] = textIn.split(' ');
 

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -83,8 +83,6 @@ export class RenderStack {
  * "div" and "where" can be either a DOM
  * element or a jQuery object.
  *
- * @class Renderer
- * @memberof music21.vfShow
  * @param {Stream} s - main stream to render
  * @param {div} [div] - existing canvas or div-surroundingSVG element
  * @param {Node|jQuery} [where=document.body] - where to render the stream

--- a/src/voiceLeading.ts
+++ b/src/voiceLeading.ts
@@ -4,8 +4,6 @@
  *
  * Copyright (c) 2013-21, Michael Scott Asato Cuthbert
  * Based on music21, Copyright (c) 2006-21, Michael Scott Asato Cuthbert
- *
- * @namespace music21.voiceLeading
  */
 
 import * as interval from './interval';
@@ -29,10 +27,6 @@ export const MotionType = {
     similar: 'Similar',
 };
 
-/**
- * @memberOf music21.voiceLeading
- * @extends Music21Object
- */
 export class VoiceLeadingQuartet extends Music21Object {
     static get className() { return 'music21.voiceLeading.VoiceLeadingQuartet'; }
 

--- a/src/webmidi.ts
+++ b/src/webmidi.ts
@@ -139,7 +139,6 @@ export function jazzMidiInArrived(t: number, a: number, b: number, c: number) {
  *
  * midiMessageEvent should be an object with two keys: timeStamp (int) and data (array of three int values)
  *
- * @memberof music21.webmidi
  * @param {Object} midiMessageEvent - midi Information
  */
 export function midiInArrived(midiMessageEvent) {
@@ -170,7 +169,6 @@ export function midiInArrived(midiMessageEvent) {
  *
  * It will return the plugin if it can or undefined if it cannot. Caches it in webmidi.storedPlugin.
  *
- * @function music21.webmidi.createPlugin
  * @param {HTMLElement} [appendElement=document.body] - where to place this hidden object (does not really matter)
  * @param {Boolean} [override=false] - if this method has been called
  *     successfully before return the storedPlugin unless override is true.
@@ -212,7 +210,6 @@ export function createPlugin(
 /**
  * Creates a &lt;select&gt; object for selecting among the MIDI choices in Jazz
  *
- * @function music21.webmidi.createJazzSelector
  * @param {jQuery|HTMLElement} [$newSelect=document.body] - object to append the select to
  * @param {Object} [options] - see createSelector for details
  * @returns {HTMLElement|undefined} DOM object containing the select tag, or undefined if Jazz cannot be loaded.

--- a/tests/moduleTests/tempo.ts
+++ b/tests/moduleTests/tempo.ts
@@ -24,7 +24,9 @@ export default function tests() {
         assert.ok(mark.textImplicit);
         assert.equal(mark.number, 40);
 
-        mark = new music21.tempo.MetronomeMark({ referent: 2 });
+        mark = new music21.tempo.MetronomeMark({
+            referent: new music21.duration.Duration('half'),
+        });
         assert.strictEqual(mark.referent.quarterLength, 2);
 
         // @ts-ignore
@@ -36,7 +38,7 @@ export default function tests() {
         mark = new music21.tempo.MetronomeMark({
             text: 'grave',
             number: 42,
-            referent: 2,
+            referent: new music21.duration.Duration('half'),
         });
         assert.equal(mark.text, 'grave', 'Expected to find set text');
         assert.notOk(mark.numberImplicit, 'Expected .numberImplicit to be false');


### PR DESCRIPTION
Remove many `{@link}` etc. tags that was driving ESLint in PyCharm, etc. crazy.

Remove use of `instanceof $` because JQuery might be loaded more than one time.

Special Case Note, etc. on RecursiveIterator