### PR TITLE
Account for measure width changes during system break calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ const n = new music21.note.Note('F#');
 
 Version
 --------
-0.11 beta
+0.12 beta
 
 
 License

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3190,7 +3190,8 @@ export class Part extends Stream {
             // read from measure render options
             let lastSystemIndex = 0;
             let workingSystemWidth = 0;
-            for (const [i, m] of Array.from(this.measures).entries()) {
+            const measure_iter = this.getElementsByClass('Measure') as iterator.StreamIterator<Measure>;
+            for (const [i, m] of Array.from(measure_iter).entries()) {
                 if (m.renderOptions.systemIndex === lastSystemIndex) {
                     workingSystemWidth += m.renderOptions.width;
                 } else {
@@ -3211,7 +3212,8 @@ export class Part extends Stream {
 
         let currentSystemIndex = 0;
 
-        for (const [i, m] of Array.from(this.measures).entries()) {
+        const measure_iter = this.getElementsByClass('Measure') as iterator.StreamIterator<Measure>;
+        for (const [i, m] of Array.from(measure_iter).entries()) {
             // values of systemBreakIndices are the measure indices
             // corresponding to the last measure on a system
             // here, looking for first measure of new system

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3112,7 +3112,7 @@ export class Part extends Stream {
      * Calculate system breaks and update measure widths as necessary on
      * account of the reiteration of clefs and key signatures on subsequent systems.
      */
-    systemWidthsAndBreaks(setMeasureWidths: boolean = true): [number[], number[]] {
+    systemWidthsAndBreaks({setMeasureWidths=true}: {setMeasureWidths?: boolean} = {}): [number[], number[]] {
         const maxSystemWidth = this.maxSystemWidth;
         const systemCurrentWidths: number[] = [];
         const systemBreakIndexes: number[] = [];
@@ -3172,8 +3172,15 @@ export class Part extends Stream {
      * returns an array of all the widths of complete systems
      * (last partial system omitted)
      */
-    fixSystemInformation(systemHeight?: number, systemPadding?: number,
-        setMeasureRenderOptions: boolean = true): number[] {
+    fixSystemInformation({
+        systemHeight = undefined,
+        systemPadding = undefined,
+        setMeasureRenderOptions = true,
+    }: {
+        systemHeight?: number,
+        systemPadding?: number,
+        setMeasureRenderOptions?: boolean,
+    } = {}): number[] {
         // this is a method on Part!
         if (systemHeight === undefined) {
             /* part.show() called... */
@@ -3523,12 +3530,16 @@ export class Score extends Stream {
                 p.measures.get(i).renderOptions.width = measureWidths[i];
             }
             // refresh system breaks again, and update lefts, but don't update widths
-            p.systemWidthsAndBreaks(false);
+            p.systemWidthsAndBreaks({setMeasureWidths: false});
         }
         for (const p of this.parts) {
             // fix system info, but no need to recalculate measure widths
             // which would undo what we just did
-            p.fixSystemInformation(currentScoreHeight, this.renderOptions.systemPadding, false);
+            p.fixSystemInformation({
+                systemHeight: currentScoreHeight,
+                systemPadding: this.renderOptions.systemPadding,
+                setMeasureRenderOptions: false,
+            });
         }
         this.renderOptions.height = this.estimateStreamHeight();
         return this;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3123,12 +3123,13 @@ export class Part extends Stream {
         let currentSystemIndex = 0;
         let currentLeft = firstMeasurePadding;
         for (const [i, m] of Array.from(this.measures).entries()) {
-            const currentRight = currentLeft + m.renderOptions.width;
             if (i === 0) {
                 m.renderOptions.startNewSystem = true;
                 m.renderOptions.displayClef = true;
                 m.renderOptions.displayKeySignature = true;
+                m.renderOptions.width = Math.min(m.renderOptions.width, maxSystemWidth);
             }
+            const currentRight = currentLeft + m.renderOptions.width;
             /* console.log('left: ' + currentLeft + ' ; right: ' + currentRight + ' ; m: ' + i); */
             if (currentRight > maxSystemWidth && lastSystemBreak !== i) {
                 /* first measure of new System */
@@ -3142,7 +3143,8 @@ export class Part extends Stream {
                 m.renderOptions.startNewSystem = true;
                 m.renderOptions.left = firstMeasurePadding;
                 if (setMeasureWidths) {
-                    m.renderOptions.width = m.estimateStaffLength() + m.renderOptions.staffPadding;
+                    const estimated_width = m.estimateStaffLength() + m.renderOptions.staffPadding;
+                    m.renderOptions.width = Math.min(estimated_width, maxSystemWidth);
                 }
             } else if (i !== 0) {
                 m.renderOptions.startNewSystem = false;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3127,7 +3127,9 @@ export class Part extends Stream {
                 m.renderOptions.startNewSystem = true;
                 m.renderOptions.displayClef = true;
                 m.renderOptions.displayKeySignature = true;
-                m.renderOptions.width = Math.min(m.renderOptions.width, maxSystemWidth);
+                if (setMeasureWidths) {
+                    m.renderOptions.width = Math.min(m.renderOptions.width, maxSystemWidth);
+                }
             }
             const currentRight = currentLeft + m.renderOptions.width;
             /* console.log('left: ' + currentLeft + ' ; right: ' + currentRight + ' ; m: ' + i); */

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3113,7 +3113,7 @@ export class Part extends Stream {
      * account of the reiteration of clefs and key signatures on subsequent systems.
      */
     systemWidthsAndBreaks(setMeasureWidths: boolean = true): [number[], number[]] {
-        const maxSystemWidth = this.maxSystemWidth; // cryptic note: 'of course fix!'?
+        const maxSystemWidth = this.maxSystemWidth;
         const systemCurrentWidths: number[] = [];
         const systemBreakIndexes: number[] = [];
         let lastSystemBreak = 0; /* needed to ensure each line has at least one measure */

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -901,7 +901,7 @@ export default function tests() {
                 p2m_renderOp_clone.partIndex = 0;
                 assert.deepEqual(p1m_renderOp_clone, p1m_renderOp_clone);
             }
-        }
+        };
 
         // get initial widths
         s.setSubstreamRenderOptions();

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -914,7 +914,7 @@ export default function tests() {
         assert.equal(p1_m1.renderOptions.systemIndex, 0);
         assert.equal(p1_m2.renderOptions.systemIndex, 1);
         assert.equal(p1_m3.renderOptions.systemIndex, 2);
-        
+
         for (let i = 0; i < p1.measures.length; i++) {
             const p1m = p1.measures.get(i);
             const p2m = p1.measures.get(i);


### PR DESCRIPTION
**Before**
`systemWidthsAndBreaks()` calculates system breaks (against `maxSystemWidth`) without taking into account new, wider measures from reiterating clef and meter on a new system, which was only done _later_ in `fixSystemInformation()`.

**Now**
The width adjustments need to be performed in the same pass as calculating system widths, so I propose moving the logic into `systemWidthsAndBreaks()`.