### PR TITLE
Guard against inserting elements multiple times

### DIFF
--- a/src/musicxml/xmlToM21.ts
+++ b/src/musicxml/xmlToM21.ts
@@ -725,8 +725,8 @@ export class MeasureParser {
 
     handleClef($mxClef) {
         const clefObj = this.xmlToClef($mxClef);
-        this.stream.clef = clefObj;
-        this.insertIntoMeasureOrVoice($mxClef, clefObj);
+        this.stream.clef = clefObj;  // inserts
+        // this.insertIntoMeasureOrVoice($mxClef, clefObj);
         this.lastClefs[0] = clefObj;
         // if (this.parent !== undefined) {
         //     this.parent.lastClefs[0] = clefObj.clone(true);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -806,7 +806,9 @@ export class Stream extends base.Music21Object {
         if (!(el instanceof base.Music21Object)) {
             throw new Music21Exception('Can only append a music21 object.');
         }
-
+        if (this._elements.includes(el)) {
+            throw new StreamException(`Cannot append (${el}): already found in Stream`);
+        }
         try {
             if (
                 el.isClassOrSubclass !== undefined
@@ -865,6 +867,9 @@ export class Stream extends base.Music21Object {
     ) {
         if (el === undefined) {
             throw new StreamException('Cannot insert without an element.');
+        }
+        if (this._elements.includes(el)) {
+            throw new StreamException(`Cannot insert (${el}): already found in Stream`);
         }
         try {
             if (!ignoreSort) {


### PR DESCRIPTION
Saw this in a personal project again and decided to quickly fix.

- Guard against inserting elements into streams multiple times
- Avoid inserting clefs into streams twice in musicxml import (Fixes #99)