### PR TITLE
makeMeasures() clones clef objects

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1252,7 +1252,7 @@ export class Stream extends base.Music21Object {
             if (measureCount === 0) {
                 // simplified...
             }
-            m.clef = clefObj;
+            m.clef = clefObj.clone();
             m.timeSignature = thisTimeSignature.clone();
 
             for (let voiceIndex = 0; voiceIndex < voiceCount; voiceIndex++) {

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -952,4 +952,20 @@ export default function tests() {
         assert.equal(p1_m3.renderOptions.systemIndex, 0);
         eachMeasureRenderOptionsEqual(p1, p2);
     });
+
+    test('music21.stream.Score makeMeasures distinct clefs', assert => {
+        const c = new music21.clef.Clef();
+        const ts = new music21.meter.TimeSignature();
+        const n = new music21.note.Note();
+        n.quarterLength = 4;
+        const n2 = new music21.note.Note();
+        n2.quarterLength = 4;
+        const s = new music21.stream.Stream();
+        for (const el of [c, ts, n, n2]) {
+            s.append(el);
+        }
+        s.makeMeasures({inPlace: true});
+        // this call will fail if there are duplicate clefs
+        assert.ok(s.flatten(true));
+    });
 }


### PR DESCRIPTION
Previously calling `flatten()` after `makeMeasures()` could raise a StreamException.