### PR TITLE
Create percussion clefs from musicxml

### DIFF
--- a/src/musicxml/xmlToM21.ts
+++ b/src/musicxml/xmlToM21.ts
@@ -737,7 +737,9 @@ export class MeasureParser {
         const sign = $($mxClef.children('sign')[0])
             .text()
             .trim();
-        // TODO: percussion, etc.
+        if (sign === 'percussion') {
+            return clef.clefFromString(sign);
+        }
         const line = $($mxClef.children('line')[0])
             .text()
             .trim();


### PR DESCRIPTION
Noticed when playing with musicxml importer in a personal project.

Clefs were being created like this, with a name of "Percussion2", which crashed when passed to the VexFlow Clef constructor.


```ts
return clef.clefFromString(sign + line, clefOctaveChange);
```