### PR TITLE
useVexflowAutobeam to false

### DIFF
--- a/src/renderOptions.ts
+++ b/src/renderOptions.ts
@@ -71,7 +71,7 @@ export class RenderOptions {
         // resize
     };
 
-    useVexflowAutobeam: boolean = true;
+    useVexflowAutobeam: boolean = false;
 
     startNewSystem: boolean = false;
     // noinspection JSUnusedGlobalSymbols

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -562,7 +562,6 @@ export default function tests() {
         const n3 = new music21.note.Note('D5');
         n3.stemDirection = 'up';
         const m = new music21.stream.Measure();
-        m.renderOptions.useVexflowAutobeam = false;
         m.timeSignature = new music21.meter.TimeSignature('2/4');
         m.append(n1);
         m.append(n2);
@@ -588,7 +587,6 @@ export default function tests() {
         const n2 = new music21.note.Note('C5', 0.5);
         const n3 = new music21.note.Note('C5', 0.5);
         const m = new music21.stream.Measure();
-        m.renderOptions.useVexflowAutobeam = false;
         m.append([ts, n1, n2, n3]);
         m.makeBeams({inPlace: true});
         assert.equal(n1.beams.beamsList.length, 0);
@@ -616,7 +614,6 @@ export default function tests() {
         const n3 = new music21.note.Note('C4', 0.5);
         const m = new music21.stream.Measure();
         m.paddingRight = 1.0;
-        m.renderOptions.useVexflowAutobeam = false;
         m.append([ts, n1, n2, n3]);
         m.makeBeams({inPlace: true});
         assert.equal(n1.beams.beamsList.length, 0);


### PR DESCRIPTION
m21j's native auto-beaming routines have matured to the point where we can make vexflow beaming opt-in (by setting this flag to default false).