### PR TITLE
Sort pitches of chord before rendering vexflow

### DIFF
--- a/src/chord.ts
+++ b/src/chord.ts
@@ -8,6 +8,7 @@
  * Chord related objects (esp. music21.chord.Chord) and methods.
  *
  */
+import Vex from 'vexflow';
 import * as MIDI from 'midicube';
 
 import { Music21Exception } from './exceptions21';
@@ -125,6 +126,10 @@ export class Chord extends note.NotRest {
         this._overrides = {};
     }
 
+    vexflowNote({ clef=undefined }={}): Vex.Flow.StaveNote {
+        this.sortPitches();
+        return super.vexflowNote({ clef });
+    }
 
     get orderedPitchClasses(): number[] {
         const pcGroup = [];


### PR DESCRIPTION
Fixes #146 

Now showing expected result from case on ticket:
<img width="499" alt="Screen Shot 2021-11-11 at 6 41 06 PM" src="https://user-images.githubusercontent.com/38668450/141384302-8afba4db-8756-4d3f-9f1e-b91c1dfbfac8.png">

