### PR TITLE
Improve support for rendering ties in voices

### DIFF
--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -402,7 +402,8 @@ export class Renderer {
      * @param {Stream} p - a Part or similar object
      */
     prepareTies(p: stream.Stream) {
-        const pf = <note.GeneralNote[]> Array.from(p.flat.notesAndRests);
+        // TODO: bridge voices across measures -- this won't get ties in voices across barlines
+        const pf = <note.GeneralNote[]> Array.from(p.recurse().notesAndRests);
         // console.log('newSystemsAt', this.systemBreakOffsets);
         for (let i = 0; i < pf.length - 1; i++) {
             const thisNote = pf[i];

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -45,4 +45,30 @@ export default function tests() {
         renderer.render();
         assert.equal(renderer.beamGroups.length, 2);
     });
+
+    test('music21.vfShow.Renderer prepareTies in voices', assert => {
+        const v1 = new music21.stream.Voice();
+        const n0 = new music21.note.Note('F4');
+        v1.repeatAppend(n0, 2);
+        const v2 = new music21.stream.Voice();
+        const n1 = new music21.note.Note('C4');
+        n1.tie = new music21.tie.Tie('start');
+        const n2 = new music21.note.Note('C4');
+        n2.tie = new music21.tie.Tie('stop');
+        v2.append(n1);
+        v2.append(n2);
+        const p = new music21.stream.Part();
+        const m = new music21.stream.Measure();
+        m.append(new music21.clef.TrebleClef());
+        m.append(new music21.meter.TimeSignature('2/4'));
+        m.insert(0, v1);
+        m.insert(0, v2);
+        p.append(m);
+
+        const svg = p.appendNewDOM();
+        const renderer = new music21.vfShow.Renderer(p, svg);
+        renderer.preparePartlike(p);
+        assert.deepEqual(renderer.vfTies[0].first_note, n1.activeVexflowNote);
+        assert.deepEqual(renderer.vfTies[0].last_note, n2.activeVexflowNote);
+    });
 }


### PR DESCRIPTION
Before, ties in voices didn't render correctly, because the render flattened the stream instead of recursing.

Now, the situation is improved, for ties in voices, within a measure. Across barlines, though, we have no voice-bridging routines, so the situation is still imperfect.

For that future work, relates to https://github.com/cuthbertLab/music21/issues/1134. We probably need a keyword arg for recurse that is `voicesFirst` or something.