### PR TITLE
lineShift -> stepShift and fix 1-line whole rest display

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -718,7 +718,7 @@ export class Note extends NotRest {
  * @property {Boolean} [isNote=false]
  * @property {Boolean} [isRest=true]
  * @property {string} [name='rest']
- * @property {number} [lineShift=undefined] - number of lines to shift up or down from default
+ * @property {number} [stepShift=0] - number of steps/lines to shift up or down from default
  * @property {string|undefined} [color='black'] - color of the rest
  */
 export class Rest extends GeneralNote {
@@ -728,7 +728,7 @@ export class Rest extends GeneralNote {
     isNote: boolean = false;
     isRest: boolean = true;
     name: string = 'rest';
-    lineShift: number = 0;
+    stepShift: number = 0;
     color: string = 'black';
     volume: number = 0;
 
@@ -756,18 +756,17 @@ export class Rest extends GeneralNote {
      */
     vexflowNote(options): Vex.Flow.StaveNote {
         let keyLine = 'b/4';
-        if (this.duration.type === 'whole') {
-            if (
-                this.activeSite !== undefined
-                && this.activeSite.renderOptions.staffLines !== 1
-            ) {
-                keyLine = 'd/5';
-            }
+        const activeSiteSingleLine = (
+            this.activeSite !== undefined
+            && this.activeSite.renderOptions.staffLines === 1
+        );
+        if (this.duration.type === 'whole' && !activeSiteSingleLine) {
+            keyLine = 'd/5';
         }
-        if (this.lineShift !== undefined) {
+        if (this.stepShift !== undefined) {
             const p = new pitch.Pitch('B4');
-            let ls = this.lineShift;
-            if (this.duration.type === 'whole') {
+            let ls = this.stepShift;
+            if (this.duration.type === 'whole' && !activeSiteSingleLine) {
                 ls += 2;
             }
             p.diatonicNoteNum += ls;

--- a/tests/moduleTests/note.ts
+++ b/tests/moduleTests/note.ts
@@ -11,4 +11,18 @@ export default function tests() {
         assert.equal(n.pitch.step, 'D', 'Pitch Step set to D');
         assert.equal(n.pitch.octave, 5, 'Pitch octave set to 5');
     });
+
+    test('music21.note.Rest.vexflowNote whole rest', assert => {
+        const r = new music21.note.Rest();
+        r.duration.type = 'whole';
+        const m = new music21.stream.Measure();
+        m.append(r);
+
+        let vfr = r.vexflowNote({});
+        assert.equal(vfr.getKeyLine(0), 4);
+
+        m.renderOptions.staffLines = 1;
+        vfr = r.vexflowNote({});
+        assert.equal(vfr.getKeyLine(0), 3);
+    });
 }


### PR DESCRIPTION
- Rename property `lineShift` -> `stepShift` to match music21 python
- fix whole rest display on 1-line staves, see:

<img width="382" alt="Screen Shot 2021-11-21 at 7 34 12 PM" src="https://user-images.githubusercontent.com/38668450/142785627-76f7fbc3-84f6-435b-bcab-084ebd03afc1.png">


