### PR TITLE
bug: act on copy when makeNotation(inPlace=false)

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1443,7 +1443,7 @@ export class Stream extends base.Music21Object {
             out = this.clone(true);
         }
         // already made a copy
-        this.makeAccidentals({ inPlace: true });
+        out.makeAccidentals({ inPlace: true });
         return out;
     }
 


### PR DESCRIPTION
On makeNotation() we were making accidentals on the source stream even when inPlace = false.