### PR TITLE
Fix regression in ties over system breaks

### DIFF
--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -403,14 +403,14 @@ export class Renderer {
      */
     prepareTies(p: stream.Stream) {
         // TODO: bridge voices across measures -- this won't get ties in voices across barlines
-        const pf = <note.GeneralNote[]> Array.from(p.recurse().notesAndRests);
+        const p_recursed = <note.GeneralNote[]> Array.from(p.recurse().notesAndRests);
         // console.log('newSystemsAt', this.systemBreakOffsets);
-        for (let i = 0; i < pf.length - 1; i++) {
-            const thisNote = pf[i];
+        for (let i = 0; i < p_recursed.length - 1; i++) {
+            const thisNote = p_recursed[i];
             if (thisNote.tie === undefined || thisNote.tie.type === 'stop') {
                 continue;
             }
-            const nextNote = pf[i + 1];
+            const nextNote = p_recursed[i + 1];
             let onSameSystem = true;
             // this.systemBreakOffsets.length will be 0 for a flat score
             for (let sbI = 0; sbI < this.systemBreakOffsets.length; sbI++) {

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -416,8 +416,8 @@ export class Renderer {
             for (let sbI = 0; sbI < this.systemBreakOffsets.length; sbI++) {
                 const thisSystemBreak = this.systemBreakOffsets[sbI];
                 if (
-                    thisNote.offset < thisSystemBreak
-                    && nextNote.offset >= thisSystemBreak
+                    thisNote.getOffsetInHierarchy(p) < thisSystemBreak
+                    && nextNote.getOffsetInHierarchy(p) >= thisSystemBreak
                 ) {
                     onSameSystem = false;
                     break;

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -71,4 +71,16 @@ export default function tests() {
         assert.deepEqual(renderer.vfTies[0].first_note, n1.activeVexflowNote);
         assert.deepEqual(renderer.vfTies[0].last_note, n2.activeVexflowNote);
     });
+
+    test('music21.vfShow.Renderer prepareTies across system break', assert => {
+        const p = <music21.stream.Part> music21.tinyNotation.TinyNotation('c1 d e~ e');
+        const s = new music21.stream.Score();
+        s.append(p);
+        s.renderOptions.maxSystemWidth = 20;
+
+        const svg = s.appendNewDOM();
+        const renderer = new music21.vfShow.Renderer(p, svg);
+        renderer.prepareScorelike(s);
+        assert.equal(renderer.vfTies.length, 2);
+    });
 }


### PR DESCRIPTION
Regression in ba7843b4d51cb0428eea5ea04b438a186b6e50f7.

Restores behavior from #56 reverted in #78. Adds test to prevent more churn.