### PR TITLE
Fix tie display in voices across barlines and move repeatAppend() to Stream

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -18,7 +18,7 @@ import * as sites from './sites';
 
 // imports for typing only
 import { Stream, Measure } from './stream';
-import {Music21Exception, StreamException} from './exceptions21';
+import {Music21Exception} from './exceptions21';
 import { TimeSignature } from './meter';
 
 
@@ -532,32 +532,6 @@ export class Music21Object extends prebase.ProtoM21Object {
             return ts.getBeatProportion(ts.getMeasureOffsetOrMeterModulusOffset(this));
         } catch (e) {
             return NaN;
-        }
-    }
-
-    /*
-        Given an object and a number, run append that many times on
-        a deepcopy of the object.
-        numberOfTimes should of course be a positive integer.
-
-        a = stream.Stream()
-        n = note.Note('D--')
-        n.duration.type = 'whole'
-        a.repeatAppend(n, 10)
-    */
-
-    repeatAppend(this, item, numberOfTimes) {
-        let unused = null;
-        try {
-            // noinspection JSUnusedAssignment
-            unused = item.isStream;
-        } catch (AttributeError) {
-            throw new StreamException('to put a non Music21Object in a stream, '
-            + 'create a music21.ElementWrapper for the item');
-
-        }
-        for (let i = 0; i < numberOfTimes; i++) {
-            this.append(item.clone(true));
         }
     }
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -898,6 +898,26 @@ export class Stream extends base.Music21Object {
     }
 
     /**
+    Given an object and a number, run append that many times on
+    a clone of the object.
+    numberOfTimes should of course be a positive integer.
+
+    a = stream.Stream()
+    n = note.Note('D--')
+    n.duration.type = 'whole'
+    a.repeatAppend(n, 10)
+    */
+    repeatAppend(item: base.Music21Object, numberOfTimes: number) {
+        if (!(item instanceof base.Music21Object)) {
+            throw new StreamException('to put a non Music21Object in a stream, '
+            + 'create a music21.ElementWrapper for the item');
+        }
+        for (let i = 0; i < numberOfTimes; i++) {
+            this.append(item.clone(true));
+        }
+    }
+
+    /**
      * Inserts a single element at offset, shifting elements at or after it begins
      * later in the stream.
      *

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -405,6 +405,8 @@ export class Renderer {
         const p_recursed = <note.GeneralNote[]> [];
         // Determine order for bridging voices: from earliest appearance
         const voice_ids_in_order_first_encountered = [];
+        // voice IDs are not necessarily unique, so track that they are visited
+        const visited_voices = <stream.Voice[]> [];
         for (const v of p.recurse().getElementsByClass('Voice')) {
             if (!voice_ids_in_order_first_encountered.includes(v.id)) {
                 voice_ids_in_order_first_encountered.push(v.id);
@@ -413,12 +415,19 @@ export class Renderer {
         // Retrieve notes in voices
         for (const v_id of voice_ids_in_order_first_encountered) {
             for (const v of p.recurse().getElementsByClass('Voice')) {
-                // retrieve notes in voices in order voice id encountered
+                // Visit in order voice id encountered
                 // For instance, all Soprano voices, then all Alto...
                 if (v.id !== v_id) {
                     continue;
                 }
+                if (!(v instanceof stream.Voice)) {
+                    throw new TypeError('Incompatible version of music21j');
+                }
+                if (visited_voices.includes(v)) {
+                    continue;
+                }
                 p_recursed.push(...Array.from((v as stream.Voice).notesAndRests));
+                visited_voices.push(v);
             }
         }
         // Retrieve notes "loose" (flat) in measures

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -402,9 +402,34 @@ export class Renderer {
      * @param {Stream} p - a Part or similar object
      */
     prepareTies(p: stream.Stream) {
-        // TODO: bridge voices across measures -- this won't get ties in voices across barlines
-        const p_recursed = <note.GeneralNote[]> Array.from(p.recurse().notesAndRests);
-        // console.log('newSystemsAt', this.systemBreakOffsets);
+        const p_recursed = <note.GeneralNote[]> [];
+        // Determine order for bridging voices: from earliest appearance
+        const voice_ids_in_order_first_encountered = [];
+        for (const v of p.recurse().getElementsByClass('Voice')) {
+            if (!voice_ids_in_order_first_encountered.includes(v.id)) {
+                voice_ids_in_order_first_encountered.push(v.id);
+            }
+        }
+        // Retrieve notes in voices
+        for (const v_id of voice_ids_in_order_first_encountered) {
+            for (const v of p.recurse().getElementsByClass('Voice')) {
+                // retrieve notes in voices in order voice id encountered
+                // For instance, all Soprano voices, then all Alto...
+                if (v.id !== v_id) {
+                    continue;
+                }
+                p_recursed.push(...Array.from((v as stream.Voice).notesAndRests));
+            }
+        }
+        // Retrieve notes "loose" (flat) in measures
+        for (const m of p.getElementsByClass('Measure')) {
+            p_recursed.push(...Array.from((m as stream.Measure).notesAndRests));
+        }
+        // Retrieve loose notes in `p` (flat)
+        p_recursed.push(...Array.from(p.notesAndRests));
+        // Other stream nesting patterns not supported
+        // prepareTies currently called by prepareArrivedFlat() and preparePartlike()
+        // supposes well-formed
         for (let i = 0; i < p_recursed.length - 1; i++) {
             const thisNote = p_recursed[i];
             if (thisNote.tie === undefined || thisNote.tie.type === 'stop') {

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -414,14 +414,11 @@ export class Renderer {
         }
         // Retrieve notes in voices
         for (const v_id of voice_ids_in_order_first_encountered) {
-            for (const v of p.recurse().getElementsByClass('Voice')) {
+            for (const v of <stream.Voice[]>(p.recurse() as any).getElementsByClass('Voice')) {
                 // Visit in order voice id encountered
                 // For instance, all Soprano voices, then all Alto...
                 if (v.id !== v_id) {
                     continue;
-                }
-                if (!(v instanceof stream.Voice)) {
-                    throw new TypeError('Incompatible version of music21j');
                 }
                 if (visited_voices.includes(v)) {
                     continue;

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -100,8 +100,8 @@ export default function tests() {
         s.append(p);
 
         // create tie in alto
-        n_m1_v2.tie = new music21.tie.Tie('start');
-        n_m2_v2.tie = new music21.tie.Tie('stop');
+        m1_alto_voice.notes.get(1).tie = new music21.tie.Tie('start');
+        m2_alto_voice.notes.get(0).tie = new music21.tie.Tie('stop');
 
         const svg = s.appendNewDOM();
         const renderer = new music21.vfShow.Renderer(p, svg);

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -94,8 +94,8 @@ export default function tests() {
         const n_m2_v2 = new music21.note.Note('E4');
         m2_alto_voice.repeatAppend(n_m2_v2, 2);
         const m2 = new music21.stream.Measure();
-        m2.append(m1_sop_voice);
-        m2.append(m1_alto_voice);
+        m2.append(m2_sop_voice);
+        m2.append(m2_alto_voice);
 
         const p = new music21.stream.Part();
         p.append(m1);
@@ -107,10 +107,8 @@ export default function tests() {
         m1_alto_voice.notes.get(1).tie = new music21.tie.Tie('start');
         m2_alto_voice.notes.get(0).tie = new music21.tie.Tie('stop');
 
-        const svg = s.appendNewDOM();
-        const renderer = new music21.vfShow.Renderer(p, svg);
-        renderer.prepareScorelike(s);
-        assert.equal(renderer.vfTies[0].first_note.line, renderer.vfTies[0].last_note.line);
+        s.appendNewDOM();
+        assert.equal(s.activeVFRenderer.vfTies[0].first_note.line, s.activeVFRenderer.vfTies[0].last_note.line);
 
         // now with random IDs
         m1_sop_voice.id = 'aaaa';
@@ -118,10 +116,8 @@ export default function tests() {
         m2_sop_voice.id = 'cccc';
         m2_alto_voice.id = 'dddd';
 
-        const svg2 = s.appendNewDOM();
-        const renderer2 = new music21.vfShow.Renderer(p, svg2);
-        renderer2.prepareScorelike(s);
-        assert.equal(renderer2.vfTies[0].first_note.line, renderer2.vfTies[0].last_note.line);
+        s.appendNewDOM();
+        assert.equal(s.activeVFRenderer.vfTies[0].first_note.line, s.activeVFRenderer.vfTies[0].last_note.line);
     });
 
     test('music21.vfShow.Renderer prepareTies across system break', assert => {

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -109,15 +109,6 @@ export default function tests() {
 
         s.appendNewDOM();
         assert.equal(s.activeVFRenderer.vfTies[0].first_note.keys[0], s.activeVFRenderer.vfTies[0].last_note.keys[0]);
-
-        // now with random IDs
-        m1_sop_voice.id = 'aaaa';
-        m1_alto_voice.id = 'bbbb';
-        m2_sop_voice.id = 'cccc';
-        m2_alto_voice.id = 'dddd';
-
-        s.appendNewDOM();
-        assert.equal(s.activeVFRenderer.vfTies[0].first_note.keys[0], s.activeVFRenderer.vfTies[0].last_note.keys[0]);
     });
 
     test('music21.vfShow.Renderer prepareTies across system break', assert => {

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -74,9 +74,11 @@ export default function tests() {
 
     test('music21.vfShow.Renderer prepareTies in voices across barline', assert => {
         const m1_sop_voice = new music21.stream.Voice();
+        m1_sop_voice.id = 'Soprano';
         const n_m1_v1 = new music21.note.Note('C5');
         m1_sop_voice.repeatAppend(n_m1_v1, 2);
         const m1_alto_voice = new music21.stream.Voice();
+        m1_alto_voice.id = 'Alto';
         const n_m1_v2 = new music21.note.Note('E4');
         m1_alto_voice.repeatAppend(n_m1_v2, 2);
         const m1 = new music21.stream.Measure();
@@ -84,9 +86,11 @@ export default function tests() {
         m1.append(m1_alto_voice);
 
         const m2_sop_voice = new music21.stream.Voice();
+        m2_sop_voice.id = 'Soprano';
         const n_m2_v1 = new music21.note.Note('C5');
         m2_sop_voice.repeatAppend(n_m2_v1, 2);
         const m2_alto_voice = new music21.stream.Voice();
+        m2_alto_voice.id = 'Alto';
         const n_m2_v2 = new music21.note.Note('E4');
         m2_alto_voice.repeatAppend(n_m2_v2, 2);
         const m2 = new music21.stream.Measure();
@@ -107,6 +111,17 @@ export default function tests() {
         const renderer = new music21.vfShow.Renderer(p, svg);
         renderer.prepareScorelike(s);
         assert.equal(renderer.vfTies[0].first_note.line, renderer.vfTies[0].last_note.line);
+
+        // now with random IDs
+        m1_sop_voice.id = 'aaaa';
+        m1_alto_voice.id = 'bbbb';
+        m2_sop_voice.id = 'cccc';
+        m2_alto_voice.id = 'dddd';
+
+        const svg2 = s.appendNewDOM();
+        const renderer2 = new music21.vfShow.Renderer(p, svg2);
+        renderer2.prepareScorelike(s);
+        assert.equal(renderer2.vfTies[0].first_note.line, renderer2.vfTies[0].last_note.line);
     });
 
     test('music21.vfShow.Renderer prepareTies across system break', assert => {

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -72,6 +72,43 @@ export default function tests() {
         assert.deepEqual(renderer.vfTies[0].last_note, n2.activeVexflowNote);
     });
 
+    test('music21.vfShow.Renderer prepareTies in voices across barline', assert => {
+        const m1_sop_voice = new music21.stream.Voice();
+        const n_m1_v1 = new music21.note.Note('C5');
+        m1_sop_voice.repeatAppend(n_m1_v1, 2);
+        const m1_alto_voice = new music21.stream.Voice();
+        const n_m1_v2 = new music21.note.Note('E4');
+        m1_alto_voice.repeatAppend(n_m1_v2, 2);
+        const m1 = new music21.stream.Measure();
+        m1.append(m1_sop_voice);
+        m1.append(m1_alto_voice);
+
+        const m2_sop_voice = new music21.stream.Voice();
+        const n_m2_v1 = new music21.note.Note('C5');
+        m2_sop_voice.repeatAppend(n_m2_v1, 2);
+        const m2_alto_voice = new music21.stream.Voice();
+        const n_m2_v2 = new music21.note.Note('E4');
+        m2_alto_voice.repeatAppend(n_m2_v2, 2);
+        const m2 = new music21.stream.Measure();
+        m2.append(m1_sop_voice);
+        m2.append(m1_alto_voice);
+
+        const p = new music21.stream.Part();
+        p.append(m1);
+        p.append(m2);
+        const s = new music21.stream.Score();
+        s.append(p);
+
+        // create tie in alto
+        n_m1_v2.tie = new music21.tie.Tie('start');
+        n_m2_v2.tie = new music21.tie.Tie('stop');
+
+        const svg = s.appendNewDOM();
+        const renderer = new music21.vfShow.Renderer(p, svg);
+        renderer.prepareScorelike(s);
+        assert.equal(renderer.vfTies[0].first_note.line, renderer.vfTies[0].last_note.line);
+    });
+
     test('music21.vfShow.Renderer prepareTies across system break', assert => {
         const p = <music21.stream.Part> music21.tinyNotation.TinyNotation('c1 d e~ e');
         const s = new music21.stream.Score();

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -108,7 +108,7 @@ export default function tests() {
         m2_alto_voice.notes.get(0).tie = new music21.tie.Tie('stop');
 
         s.appendNewDOM();
-        assert.equal(s.activeVFRenderer.vfTies[0].first_note.line, s.activeVFRenderer.vfTies[0].last_note.line);
+        assert.equal(s.activeVFRenderer.vfTies[0].first_note.keys[0], s.activeVFRenderer.vfTies[0].last_note.keys[0]);
 
         // now with random IDs
         m1_sop_voice.id = 'aaaa';
@@ -117,7 +117,7 @@ export default function tests() {
         m2_alto_voice.id = 'dddd';
 
         s.appendNewDOM();
-        assert.equal(s.activeVFRenderer.vfTies[0].first_note.line, s.activeVFRenderer.vfTies[0].last_note.line);
+        assert.equal(s.activeVFRenderer.vfTies[0].first_note.keys[0], s.activeVFRenderer.vfTies[0].last_note.keys[0]);
     });
 
     test('music21.vfShow.Renderer prepareTies across system break', assert => {


### PR DESCRIPTION
Fixes tie display in voices across barlines. <s>But raises an error in Vex Flow I haven't debugged yet.</s> Fixed!

Update: moves `repeatAppend()` to `Stream`