### PR TITLE
estimateStaffLength() fixes

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1969,8 +1969,7 @@ export class Stream extends base.Music21Object {
      * @returns {number} length in pixels
      */
     estimateStaffLength() {
-        let i;
-        let totalLength;
+        let totalLength: number;
         if (this.renderOptions.overriddenWidth !== undefined) {
             // console.log('Overridden staff width: ' + this.renderOptions.overriddenWidth);
             return this.renderOptions.overriddenWidth;
@@ -1986,11 +1985,10 @@ export class Stream extends base.Music21Object {
                     }
                 }
             }
-            return maxLength;
+            totalLength = maxLength;
         } else if (!this.isFlat) {
             // part
-            totalLength = 0;
-            for (i = 0; i < this.length; i++) {
+            for (let i = 0; i < this.length; i++) {
                 const m = this.get(i);
                 if (m instanceof Stream) {
                     totalLength
@@ -2000,23 +1998,27 @@ export class Stream extends base.Music21Object {
                     }
                 }
             }
-            return totalLength;
         } else {
-            const rendOp = this.renderOptions;
             totalLength = 30 * this.notesAndRests.length;
-            if (rendOp.displayClef) {
-                totalLength += 30;
-            }
-            if (rendOp.displayKeySignature) {
-                const ks = this.getSpecialContext('keySignature');
-                totalLength += ks?.width ?? 0;
-            }
-            if (rendOp.displayTimeSignature) {
-                totalLength += 30;
-            }
-            // totalLength += rendOp.staffPadding;
+        }
+        if (this instanceof Voice) {
+            // recursive call: return early so that measure call
+            // pads just once for clef/key/meter
             return totalLength;
         }
+        const rendOp = this.renderOptions;
+        if (rendOp.displayClef) {
+            totalLength += 30;
+        }
+        if (rendOp.displayKeySignature) {
+            const ks = this.getSpecialContext('keySignature') || this.getContextByClass('KeySignature');
+            totalLength += ks?.width ?? 0;
+        }
+        if (rendOp.displayTimeSignature) {
+            totalLength += 30;
+        }
+        // totalLength += rendOp.staffPadding;
+        return totalLength;
     }
 
     stripTies(

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -1014,4 +1014,26 @@ export default function tests() {
         // this call will fail if there are duplicate clefs
         assert.ok(s.flatten(true));
     });
+
+    test('music21.stream.Stream estimateStaffLength', assert => {
+        const v = new music21.stream.Voice();
+        const n = new music21.note.Note();
+        n.duration.type = 'whole';
+        v.append(n);
+        const m = new music21.stream.Measure();
+        m.append(v);
+        const original_width = m.estimateStaffLength();
+        const ks = new music21.key.KeySignature(-6);
+        m.append(ks);
+        m.renderOptions.displayKeySignature = true;
+        assert.equal(m.estimateStaffLength(), original_width + ks.width);
+
+        // Also test getting KeySignature from the context
+        const previous_measure = m.clone();
+        m.remove(ks);
+        const p = new music21.stream.Part();
+        p.append(previous_measure);
+        p.append(m);
+        assert.equal(m.estimateStaffLength(), original_width + ks.width);
+    });
 }


### PR DESCRIPTION
Fixes some issues in `estimateStaffLength()`

1. don't return so early if voices are found: finish checking for renderOptions values for `displayKeySignature`, etc.
2. get key signature from the context (instead of depending on it being in specialContext)