### PR TITLE
Recalculate accidental display when redisplaying a stream

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1455,15 +1455,15 @@ export class Stream extends base.Music21Object {
      *
      * TODO: move call to makeBeams from renderVexflow to here.
      */
-    makeNotation({ inPlace=true }={}): this {
-        let out;
+    makeNotation({ inPlace=true, overrideStatus=false }={}): this {
+        let out: this;
         if (inPlace) {
             out = this;
         } else {
             out = this.clone(true);
         }
         // already made a copy
-        out.makeAccidentals({ inPlace: true });
+        out.makeAccidentals({ inPlace: true, overrideStatus });
         return out;
     }
 

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -307,7 +307,8 @@ export class Renderer {
      * optional_renderOp - renderOptions passed to music21.vfShow.Renderer#renderStave
      * returns Vex.Flow.Stave staff to return too
      *
-     * (also changes the `stack` parameter and runs `makeNotation` on s)
+     * (also changes the `stack` parameter and runs `makeNotation` on s
+     * with overrideStatus: true to update accidental display)
      */
     prepareFlat(
         s: stream.Stream,
@@ -315,8 +316,8 @@ export class Renderer {
         optionalStave?: Vex.Flow.Stave,
         optional_renderOp?: renderOptions.RenderOptions,
     ): Vex.Flow.Stave {
-        s.makeNotation();
-        let stave;
+        s.makeNotation({ overrideStatus: true });
+        let stave: Vex.Flow.Stave;
         if (optionalStave !== undefined) {
             stave = optionalStave;
         } else {

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -122,4 +122,23 @@ export default function tests() {
         renderer.prepareScorelike(s);
         assert.equal(renderer.vfTies.length, 2);
     });
+
+    test('music21.vfShow.Renderer.prepareFlat recalculates accidental display', assert => {
+        const p = <music21.stream.Part> music21.tinyNotation.TinyNotation('d4 d# d# d#');
+        const s = new music21.stream.Score();
+        s.append(p);
+        s.appendNewDOM();
+        const notes_iter = p.recurse().notes;
+        const first_note = notes_iter.get(0);
+        const second_note = notes_iter.get(1);
+        assert.equal(first_note.pitch.accidental, undefined);
+        assert.equal(second_note.pitch.accidental.displayStatus, true);
+
+        // D -> D#
+        const aug_1 = new music21.interval.Interval('A1');
+        first_note.pitch = aug_1.transposePitch(first_note.pitch);
+        s.replaceDOM();
+        assert.equal(first_note.pitch.accidental.displayStatus, true);
+        assert.equal(second_note.pitch.accidental.displayStatus, false);
+    });
 }


### PR DESCRIPTION
Add `override_status` to makeNotation() and set it True when calling from prepareFlat().

Regression test fails on current version.