### PR TITLE
Display measure numbers set on Measure objects if defined

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1705,7 +1705,7 @@ export class Stream extends base.Music21Object {
 
         If `cautionaryAll` is true, all accidentals are shown.
 
-        If `overrideStatus` is true, this method will ignore any current `displayStatus` stetting
+        If `overrideStatus` is true, this method will ignore any current `displayStatus` setting
         found on the Accidental. By default this does not happen. If `displayStatus` is set to
         None, the Accidental's `displayStatus` is set.
 

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -705,7 +705,11 @@ export class Renderer {
 
         this.setStafflines(s, stave);
         if (rendOp.showMeasureNumber) {
-            stave.setMeasure(rendOp.measureIndex + 1);
+            if (s instanceof stream.Measure && s.number !== undefined) {
+                stave.setMeasure(s.number);
+            } else {
+                stave.setMeasure(rendOp.measureIndex + 1);
+            }
         }
 
         let displayClef = rendOp.displayClef;

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -141,4 +141,23 @@ export default function tests() {
         assert.equal(first_note.pitch.accidental.displayStatus, true);
         assert.equal(second_note.pitch.accidental.displayStatus, false);
     });
+
+    test('music21.vfShow.Renderer obeys measure numbers', assert => {
+        const p = <music21.stream.Part> music21.tinyNotation.TinyNotation('c4 d1 e~ e');
+        const measure_iter = p.getElementsByClass('Measure') as music21.stream.iterator.StreamIterator<music21.stream.Measure>;
+        measure_iter.get(0).paddingLeft = 3.0;
+        for (const [i, m] of Array.from(measure_iter).entries()) {
+            // Renumber the measures so that pickup is m.0
+            m.number = i;
+            m.renderOptions.showMeasureNumber = true;
+        }
+        p.appendNewDOM();
+        for (const stack of p.activeVFRenderer.stacks) {
+            const vf_voice = stack.voices[0];
+            assert.equal(
+                vf_voice.stave.measure,
+                (stack.voiceToStreamMapping.get(vf_voice) as music21.stream.Measure).number
+            );
+        }
+    });
 }


### PR DESCRIPTION
Previously, when the `showMeasureNumber` render option was used, the numbers used always began at 1, so there was no good solution for pickups.

Now, if a user has set `.number` appropriately on `Measure` objects, that number is used in lieu of the _actual_ 1-indexed position.

Regression test fails on master.