### PR TITLE
Fix accidental status overriding for initial diatonic naturals

### DIFF
--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -675,8 +675,8 @@ export class Pitch extends prebase.ProtoM21Object {
             // if we have no past, we show the accidental if this accidental
             // is not in the alteredPitches list, or vice versa for naturals
             if (acc_orig !== undefined
-                && (display_orig === false
-                    || display_orig === undefined)) {
+                && (overrideStatus || (display_orig === false
+                    || display_orig === undefined))) {
                 if (this.accidental.name === 'natural') {
                     this.accidental.displayStatus = this._stepInKeySignature(alteredPitches);
                 } else {

--- a/tests/moduleTests/pitch.ts
+++ b/tests/moduleTests/pitch.ts
@@ -316,6 +316,14 @@ export default function tests() {
         assert.equal(n.pitch.accidental.displayStatus, true);
     });
 
+    test('music21.pitch.updateAccidentalDisplay respects overrideStatus', assert => {
+        const n = new music21.note.Note('Cn');
+        n.pitch.accidental.displayStatus = true;
+        const k = new music21.key.Key('C');
+        n.pitch.updateAccidentalDisplay({overrideStatus: true, alteredPitches: k.alteredPitches});
+        assert.equal(n.pitch.accidental.displayStatus, false);
+    });
+
     /* // Transpose is Not Implemented in pitch class
     test('music21.pitch.Low Notes', assert => {
         const dPitch = new music21.pitch.Pitch('D2');


### PR DESCRIPTION
Port of https://github.com/cuthbertLab/music21/pull/1198