### PR TITLE
fix cloneEmpty()

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -28,6 +28,7 @@ import { debug } from './debug';
 import * as base from './base';
 import * as clef from './clef';
 import * as common from './common';
+import * as derivation from './derivation';
 import { Duration } from './duration';
 import * as instrument from './instrument';
 import * as meter from './meter';
@@ -1438,8 +1439,11 @@ export class Stream extends base.Music21Object {
     }
 
     cloneEmpty(derivationMethod?: string): this {
-        const returnObj = this.constructor();
-        // TODO(msc): derivation
+        const returnObj = new (this as any).constructor();
+        const new_derivation = new derivation.Derivation(returnObj);
+        new_derivation.origin = this;
+        new_derivation.method = derivationMethod || 'cloneEmpty';
+        returnObj.derivation = new_derivation;
         returnObj.mergeAttributes(this);
         return returnObj;
     }

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -1046,4 +1046,12 @@ export default function tests() {
         p.append(m);
         assert.equal(m.estimateStaffLength(), original_width + ks.width);
     });
+
+    test('music21.stream.Stream cloneEmpty', assert => {
+        const p = music21.tinyNotation.TinyNotation('3/4 c4 BB c d4 e2.');
+        const empty = p.cloneEmpty();
+        assert.true(empty instanceof music21.stream.Part);
+        assert.equal(empty.elements.length, 0);
+        assert.equal(empty.derivation.method, 'cloneEmpty');
+    });
 }


### PR DESCRIPTION
`cloneEmpty()` (eventually needed for chordify/template) wasn't working, with a warning about constructors needing the `new` keyword.