### PR TITLE
Add partName and partAbbreviation to `Part`

### DIFF
--- a/src/musicxml/xmlToM21.ts
+++ b/src/musicxml/xmlToM21.ts
@@ -131,8 +131,11 @@ export class ScoreParser {
         // const openPartGroups = [];
         for (const partListElement of mxPartList) {
             const $partListElement = $(partListElement);
-            const partId = $partListElement.attr('id');
-            this.mxScorePartDict[partId] = $partListElement;
+            for (const scorePartElement of $partListElement.children('score-part')) {
+                const $scorePartElement = $(scorePartElement);
+                const partId = $scorePartElement.attr('id');
+                this.mxScorePartDict[partId] = $scorePartElement;
+            }
         }
         // deal with part-groups
     }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3101,10 +3101,46 @@ export class Part extends Stream {
     static get className() { return 'music21.stream.Part'; }
 
     recursionType: string = 'flatten';
+    _partName: string;
+    _partAbbreviation: string;
 
     // constructor() {
     //     super();
     // }
+
+    /**
+     * The name of this part; if undefined, look up on the stored instrument.
+     */
+    get partName(): string {
+        if (this._partName !== undefined) {
+            return this._partName;
+        }
+        if (this.instrument instanceof instrument.Instrument) {
+            return this.instrument.partName;
+        }
+        return undefined;
+    }
+
+    set partName(name: string) {
+        this._partName = name;
+    }
+
+    /**
+     * The abbreviated name of this part; if undefined, look up on the stored instrument.
+     */
+    get partAbbreviation(): string {
+        if (this._partAbbreviation !== undefined) {
+            return this._partAbbreviation;
+        }
+        if (this.instrument instanceof instrument.Instrument) {
+            return this.instrument.partAbbreviation;
+        }
+        return undefined;
+    }
+
+    set partAbbreviation(name: string) {
+        this._partAbbreviation = name;
+    }
 
     /**
      * How many systems does this Part have?


### PR DESCRIPTION
(A personal project imports musicxml files.)

m21j's importer attempts to set `Part.partName` already, but it didn't exist.