### PR TITLE
Account for lyrics when calculating staff length

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -2011,7 +2011,7 @@ export class Stream extends base.Music21Object {
      * @returns {number} length in pixels
      */
     estimateStaffLength() {
-        let totalLength: number;
+        let totalLength = 0;
         if (this.renderOptions.overriddenWidth !== undefined) {
             // console.log('Overridden staff width: ' + this.renderOptions.overriddenWidth);
             return this.renderOptions.overriddenWidth;
@@ -2041,7 +2041,14 @@ export class Stream extends base.Music21Object {
                 }
             }
         } else {
-            totalLength = 30 * this.notesAndRests.length;
+            for (const nr of this.notesAndRests) {
+                // if .lyric is > 4 characters, we start padding the length
+                if (nr.lyric !== undefined) {
+                    totalLength += Math.max(30, 7 * nr.lyric.length);
+                } else {
+                    totalLength += 30;
+                }
+            }
         }
         if (this instanceof Voice) {
             // recursive call: return early so that measure call

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -2044,7 +2044,7 @@ export class Stream extends base.Music21Object {
             for (const nr of this.notesAndRests) {
                 // if .lyric is > 4 characters, we start padding the length
                 if (nr.lyric !== undefined) {
-                    totalLength += Math.max(30, 7 * nr.lyric.length);
+                    totalLength += Math.max(30, ((7 * nr.lyric.length) + 2));
                 } else {
                     totalLength += 30;
                 }

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -1046,8 +1046,8 @@ export default function tests() {
         p.append(m);
         assert.equal(m.estimateStaffLength(), original_width + ks.width);
 
-        n.lyric = 'lorem';  // 7px * 5 letters = 35, original width otherwise starts at 30
-        assert.equal(m.estimateStaffLength(), original_width + 5 + ks.width);
+        n.lyric = 'lorem';  // (7px * 5 letters + 2) = 37, original width otherwise starts at 30
+        assert.equal(m.estimateStaffLength(), original_width + 7 + ks.width);
     });
 
     test('music21.stream.Stream cloneEmpty', assert => {

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -1045,6 +1045,9 @@ export default function tests() {
         p.append(previous_measure);
         p.append(m);
         assert.equal(m.estimateStaffLength(), original_width + ks.width);
+
+        n.lyric = 'lorem';  // 7px * 5 letters = 35, original width otherwise starts at 30
+        assert.equal(m.estimateStaffLength(), original_width + 5 + ks.width);
     });
 
     test('music21.stream.Stream cloneEmpty', assert => {


### PR DESCRIPTION
Improve staff spacing when there are lyrics (reduce text collisions).