### PR TITLE
Fix clearing of alteredPitches when setting sharps

### DIFF
--- a/src/key.ts
+++ b/src/key.ts
@@ -95,7 +95,7 @@ export class KeySignature extends base.Music21Object {
     }
 
     set sharps(s: number) {
-        this._alteredPitchesCache = [];
+        this._alteredPitchesCache = undefined;
         this._sharps = s;
     }
 

--- a/tests/moduleTests/key.ts
+++ b/tests/moduleTests/key.ts
@@ -62,4 +62,10 @@ export default function tests() {
 
         assert.equal(k.width, 42, 'checking width');
     });
+
+    test('music21.key.KeySignature setting sharps updates alteredPitches', assert => {
+        const ks = new music21.key.KeySignature();
+        ks.sharps = -4;
+        assert.equal(`${ks.alteredPitches.map(p => p.name)}`, 'B-,E-,A-,D-');
+    });
 }


### PR DESCRIPTION
`[]` signifies zero alteredPitches, not a lack of information.

Found (and fixed) as part of working on a personal project.