### PR TITLE
Hide left barline at system beginnings

### DIFF
--- a/src/renderOptions.ts
+++ b/src/renderOptions.ts
@@ -61,7 +61,7 @@ export class RenderOptions {
     // scaleFactors.
     maxSystemWidth: number = undefined;
 
-    leftBarline: string = undefined;  // normally not used.
+    leftBarline: string = undefined;  // render() sets to 'none' for system beginnings
     rightBarline: string = undefined;
 
     staffLines: number = 5;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3284,11 +3284,9 @@ export class Part extends Stream {
     fixSystemInformation({
         systemHeight = undefined,
         systemPadding = undefined,
-        setMeasureRenderOptions = true,
     }: {
         systemHeight?: number,
         systemPadding?: number,
-        setMeasureRenderOptions?: boolean,
     } = {}): number[] {
         // this is a method on Part!
         if (systemHeight === undefined) {
@@ -3297,26 +3295,22 @@ export class Part extends Stream {
         } else if (debug) {
             console.log('overridden systemHeight: ' + systemHeight);
         }
-        let systemCurrentWidths = [];
-        let systemBreakIndexes = [];
-        if (setMeasureRenderOptions) {
-            [systemCurrentWidths, systemBreakIndexes] = this.systemWidthsAndBreaks();
-        }
-        else {
-            // read from measure render options
-            let lastSystemIndex = 0;
-            let workingSystemWidth = 0;
-            const measure_iter = this.getElementsByClass('Measure') as iterator.StreamIterator<Measure>;
-            for (const [i, m] of Array.from(measure_iter).entries()) {
-                if (m.renderOptions.systemIndex === lastSystemIndex) {
-                    workingSystemWidth += m.renderOptions.width;
-                } else {
-                    systemCurrentWidths.push(workingSystemWidth);
-                    systemBreakIndexes.push(i - 1);
-                    workingSystemWidth = m.renderOptions.width;
-                }
-                lastSystemIndex = m.renderOptions.systemIndex;
+        const systemCurrentWidths = [];
+        const systemBreakIndexes = [];
+
+        // read from measure render options
+        let lastSystemIndex = 0;
+        let workingSystemWidth = 0;
+        const measure_iter = this.getElementsByClass('Measure') as iterator.StreamIterator<Measure>;
+        for (const [i, m] of Array.from(measure_iter).entries()) {
+            if (m.renderOptions.systemIndex === lastSystemIndex) {
+                workingSystemWidth += m.renderOptions.width;
+            } else {
+                systemCurrentWidths.push(workingSystemWidth);
+                systemBreakIndexes.push(i - 1);
+                workingSystemWidth = m.renderOptions.width;
             }
+            lastSystemIndex = m.renderOptions.systemIndex;
         }
         if (systemPadding === undefined) {
             systemPadding = this.renderOptions.systemPadding;
@@ -3328,7 +3322,6 @@ export class Part extends Stream {
 
         let currentSystemIndex = 0;
 
-        const measure_iter = this.getElementsByClass('Measure') as iterator.StreamIterator<Measure>;
         for (const [i, m] of Array.from(measure_iter).entries()) {
             // values of systemBreakIndices are the measure indices
             // corresponding to the last measure on a system
@@ -3642,12 +3635,9 @@ export class Score extends Stream {
             p.systemWidthsAndBreaks({setMeasureWidths: false});
         }
         for (const p of this.parts) {
-            // fix system info, but no need to recalculate measure widths
-            // which would undo what we just did
             p.fixSystemInformation({
                 systemHeight: currentScoreHeight,
                 systemPadding: this.renderOptions.systemPadding,
-                setMeasureRenderOptions: false,
             });
         }
         this.renderOptions.height = this.estimateStreamHeight();

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -206,7 +206,7 @@ export class Renderer {
         if (isScorelike) {
             this.prepareScorelike(s as stream.Score);
         } else if (isPartlike) {
-            this.preparePartlike(s as stream.Part);
+            this.preparePartlike(s as stream.Part, {multipart: false});
         } else {
             this.prepareArrivedFlat(s);
         }
@@ -227,7 +227,7 @@ export class Renderer {
         //
         const parts = s.parts;
         for (const subStream of parts) {
-            this.preparePartlike(subStream);
+            this.preparePartlike(subStream, {multipart: s.parts.length > 1});
         }
         this.addStaffConnectors(s);
     }
@@ -238,7 +238,7 @@ export class Renderer {
      * or substreams that should be considered like Measures)
      * for rendering.
      */
-    preparePartlike(p: stream.Part) {
+    preparePartlike(p: stream.Part, {multipart = false}: {multipart?: boolean} = {}) {
         // console.log('preparePartlike called');
         this.systemBreakOffsets = [];
         const measureList = p.measures;
@@ -246,6 +246,9 @@ export class Renderer {
             const subStream = measureList.get(i);
             if (subStream.renderOptions.startNewSystem) {
                 this.systemBreakOffsets.push(subStream.offset);
+                if (!multipart) {
+                    subStream.renderOptions.leftBarline = 'none';
+                }
             }
             if (i === p.length - 1 && subStream.renderOptions.rightBarline === undefined) {
                 subStream.renderOptions.rightBarline = 'end';
@@ -267,6 +270,7 @@ export class Renderer {
      */
     prepareArrivedFlat(m: stream.Stream) {
         const stack = new RenderStack();
+        m.renderOptions.leftBarline = 'none';
         this.prepareMeasure(m as stream.Measure, stack);
         this.stacks[0] = stack;
         this.prepareTies(m);


### PR DESCRIPTION
Hide the left barline at the beginning of a single measure, a single part, or a single-part score.

One cleanup commit removes an unused option added in 8319c6f99ccac543d09043e2048add8da7821124 (unnecessary concern about backward-compat, I guess)