### PR TITLE
Fix setting dots to 0 when ql is 0

### DIFF
--- a/src/duration.ts
+++ b/src/duration.ts
@@ -266,6 +266,9 @@ export class Duration extends prebase.ProtoM21Object {
 
     updateQlFromFeatures() {
         const typeNumber = ordinalTypeFromNum.indexOf(this._type); // must be set property
+        if (typeNumber === -1) {
+            return;  // e.g. "zero" type
+        }
         const undottedQuarterLength = (
             2 ** (quarterTypeIndex - typeNumber)
         );

--- a/tests/moduleTests/duration.ts
+++ b/tests/moduleTests/duration.ts
@@ -10,6 +10,10 @@ export default function tests() {
         assert.equal(d.type, 'zero', 'got zero');
         assert.equal(d.dots, 0, 'got no dots');
         assert.equal(d.quarterLength, 0.0, 'got 0.0');
+
+        d.dots = 0;
+        assert.equal(d.dots, 0, 'still no dots');
+        assert.equal(d.quarterLength, 0.0, 'still 0.0');
     });
 
     test('music21.duration.Duration', assert => {


### PR DESCRIPTION
Previously, setting dots to 0 when ql was 0 would set ql to 128.