### PR TITLE
Strip "tinyNotation: " from TinyNotation strings

### DIFF
--- a/src/tinyNotation.ts
+++ b/src/tinyNotation.ts
@@ -70,6 +70,12 @@ const regularExpressions: { [k: string]: RegExp } = {
  */
 export function TinyNotation(textIn: string): stream.Part|stream.Score {
     textIn = textIn.trim();
+    // compatibility with "tinyNotation: " in m21p
+    const indexOfOptionalPrefix = textIn.toLowerCase().indexOf('tinynotation: ');
+    if (indexOfOptionalPrefix !== -1) {
+        textIn = textIn.slice(indexOfOptionalPrefix);
+    }
+
     const tokens: string[] = textIn.split(' ');
 
     let optionalScore: stream.Score;

--- a/tests/moduleTests/pitch.ts
+++ b/tests/moduleTests/pitch.ts
@@ -277,29 +277,24 @@ export default function tests() {
     test('music21.pitch.Accidentals Cautionary', assert => {
         //const conv = music21.key.convertKeyStringToMusic21KeyString;
         const convertedNotes = music21.tinyNotation.TinyNotation(
-            "tinynotation: 4/4 fn1 fn1 e-8 e'-8 fn4 en4 e'n4"
+            "4/4 fn1 fn1 e-8 e'-8 fn4 en4 e'n4"
         ).flat;
         // Function does not work, stream.ts 1353
         //convertedNotes.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False);
 
-        // Possible bug, first note has accidental information undefined
-        assert.equal(convertedNotes.elements[2].pitches.accidental, undefined, 'Undefined');
-
-        // displayStatus not defined in Note class, or Renamed
-        // assert.equal(convertedNotes.elements[2].pitch.accName.displayStatus, 'True');
+        assert.equal(convertedNotes.elements[2].pitch.accidental.name, 'natural', 'Natural');
+        //assert.equal(convertedNotes.elements[2].pitch.accidental.displayStatus, 'True');
         assert.equal(convertedNotes.elements[3].pitch.accidental.name, 'natural', 'Natural');
         //assert.equal(convertedNotes.elements[3].pitch.accidental.displayStatus, 'True');
-        assert.equal(convertedNotes.elements[4].pitch.accidental.name, 'natural', 'Natural');
+        assert.equal(convertedNotes.elements[4].pitch.accidental.name, 'flat', 'Flat');
         //assert.equal(convertedNotes.elements[4].pitch.accidental.displayStatus, 'True');
         assert.equal(convertedNotes.elements[5].pitch.accidental.name, 'flat', 'Flat');
         //assert.equal(convertedNotes.elements[5].pitch.accidental.displayStatus, 'True');
-        assert.equal(convertedNotes.elements[6].pitch.accidental.name, 'flat', 'Flat');
+        assert.equal(convertedNotes.elements[6].pitch.accidental.name, 'natural', 'Natural');
         //assert.equal(convertedNotes.elements[6].pitch.accidental.displayStatus, 'True');
-        assert.equal(convertedNotes.elements[7].pitch.accidental.name, 'natural', 'Natural');
-        //assert.equal(convertedNotes.elements[7].pitch.accidental.displayStatus, 'True');
-        assert.notEqual(convertedNotes.elements[8].pitch.accidental, 'None', 'None');
-        assert.notEqual(convertedNotes.elements[8].pitch.accidental.name, 'flat', 'Natural');
-        //assert.notEqual(convertedNotes.notes[8].pitch.accidental.displayStatus, 'True');
+        assert.notEqual(convertedNotes.elements[7].pitch.accidental, 'None', 'None');
+        assert.notEqual(convertedNotes.elements[7].pitch.accidental.name, 'flat', 'Natural');
+        //assert.notEqual(convertedNotes.notes[7].pitch.accidental.displayStatus, 'True');
     });
 
     test('music21.pitch.updateAccidentalDisplay nonconsecutive chromatic pitches', assert => {


### PR DESCRIPTION
Fixes #163 -- strips `"tinyNotation: "` (or lowercase) from TinyNotation strings, for compatibility with the Python `converter.parse` API.