### PR TITLE
Fix implementation of #192 and add test

### DIFF
--- a/src/tinyNotation.ts
+++ b/src/tinyNotation.ts
@@ -71,9 +71,8 @@ const regularExpressions: { [k: string]: RegExp } = {
 export function TinyNotation(textIn: string): stream.Part|stream.Score {
     textIn = textIn.trim();
     // compatibility with "tinyNotation: " in m21p
-    const indexOfOptionalPrefix = textIn.toLowerCase().indexOf('tinynotation: ');
-    if (indexOfOptionalPrefix !== -1) {
-        textIn = textIn.slice(indexOfOptionalPrefix);
+    if (textIn.slice(0, 14).toLowerCase() === 'tinynotation: ') {
+        textIn = textIn.slice(14);
     }
 
     const tokens: string[] = textIn.split(' ');

--- a/tests/loadAll.ts
+++ b/tests/loadAll.ts
@@ -23,6 +23,7 @@ import sites from './moduleTests/sites';
 import stream from './moduleTests/stream';
 import tempo from './moduleTests/tempo';
 import tie from './moduleTests/tie';
+import tinyNotation from './moduleTests/tinyNotation';
 import vfShow from './moduleTests/vfShow';
 import voiceLeading from './moduleTests/voiceLeading';
 
@@ -51,6 +52,7 @@ const allTests = {
     sites,
     stream,
     tempo,
+    tinyNotation,
     tie,
     vfShow,
     voiceLeading,

--- a/tests/moduleTests/tinyNotation.ts
+++ b/tests/moduleTests/tinyNotation.ts
@@ -1,0 +1,12 @@
+import * as QUnit from 'qunit';
+import * as music21 from '../../src/main';
+
+const { test } = QUnit;
+
+
+export default function tests() {
+    test('music21.tinyNotation.TinyNotation optional prefix', assert => {
+        const p = music21.tinyNotation.TinyNotation('tinyNotation: fn1');
+        assert.equal(p.recurse().notes.length, 1);
+    });
+}


### PR DESCRIPTION
Working a bit hastily this evening. #192 wasn't quite right -- fixed and added a test (and avoided an `indexOf` scan in case strings are long).