### PR TITLE
Fix makeAccidentals regression involving cautionaryPitchClass and chords

### DIFF
--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -671,7 +671,7 @@ export class Pitch extends prebase.ProtoM21Object {
             if (p.step !== this.step) {
                 return false;
             }
-            return p.nameWithOctave !== this.nameWithOctave;
+            return p.pitchClass !== this.pitchClass;
         }
 
         if (

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -562,6 +562,14 @@ export default function tests() {
         assert.ok(c.pitches[0].accidental.displayStatus);
     });
 
+    test('music21.stream.Stream makeAccidentals perfect octave in chord', assert => {
+        const m = new music21.stream.Measure();
+        const c = new music21.chord.Chord('G4 G5');
+        m.append(c);
+        m.makeAccidentals({inPlace: true});
+        assert.notOk(c.pitches[0].accidental?.displayStatus);
+    });
+
     test('music21.stream.Stream makeBeams with stemDirection', assert => {
         const n1 = new music21.note.Note('C5', 0.5);
         n1.stemDirection = 'up';


### PR DESCRIPTION
Before, octaves in chords could receive superfluous accidentals if `cautionaryPitchClass`  was true (default).

#190 was incorrectly ported from python: I suppose I wasn't sure if m21j had `pitchClass` defined, but it does, so I should have just used that as the python implementation (cuthbertLab/music21#1323) does.