### PR TITLE
Don't draw hideObjectOnPrint notes/rests

### DIFF
--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -921,6 +921,7 @@ export class Renderer {
             if (
                 thisEl.isClassOrSubclass('GeneralNote')
                 && thisEl.duration !== undefined
+                && !(thisEl.style.hideObjectOnPrint)
             ) {
                 // sets thisEl.activeVexflowNote -- may be overwritten but not so fast...
                 const vfn = (thisEl as note.GeneralNote).vexflowNote(options);


### PR DESCRIPTION
Avoid drawing notes and rests with `hideObjectOnPrint` set to `true`.