### PR TITLE
type .editorial as a record for usage

### DIFF
--- a/.idea/dictionaries/cuthbert.xml
+++ b/.idea/dictionaries/cuthbert.xml
@@ -222,6 +222,7 @@
       <w>tetrachord</w>
       <w>tetracluster</w>
       <w>tetramirror</w>
+      <w>tickable</w>
       <w>tickables</w>
       <w>timesig</w>
       <w>tinynotation</w>

--- a/src/base.ts
+++ b/src/base.ts
@@ -52,7 +52,7 @@ export class Music21Object extends prebase.ProtoM21Object {
     protected _naiveOffset: number = 0;
     // _derivation = undefined;
     protected _style: style.Style;
-    protected _editorial: editorial.Editorial;
+    protected _editorial: Record<string, any>;  // actually editorial.Editorial
     protected _duration: duration.Duration;
     protected _derivation: derivation.Derivation;
     protected _priority: number = 0;
@@ -157,15 +157,19 @@ export class Music21Object extends prebase.ProtoM21Object {
         this._derivation = newDerivation;
     }
 
-    get editorial(): editorial.Editorial {
+    /**
+     * Note that the editorial is typed as Record<string, any>
+     *     but actually returns an editorial object
+     */
+    get editorial(): Record<string, any> {
         if (this._editorial === undefined) {
             this._editorial = new editorial.Editorial();
         }
         return this._editorial;
     }
 
-    set editorial(newEditorial: editorial.Editorial) {
-        this._editorial = newEditorial;
+    set editorial(newEditorial: editorial.Editorial|Record<string, any>) {
+        this._editorial = newEditorial as any;
     }
 
     get hasEditorialInformation(): boolean {

--- a/src/editorial.ts
+++ b/src/editorial.ts
@@ -8,7 +8,7 @@
 
 import { ProtoM21Object } from './prebase';
 
-export class Editorial extends ProtoM21Object {
+export class Editorial extends ProtoM21Object implements Record<string, any> {
     static get className() { return 'music21.editorial.Editorial'; }
 
     comments: any[] = [];

--- a/src/miditools.ts
+++ b/src/miditools.ts
@@ -223,7 +223,7 @@ export function makeChords(jEvent: Event): void {
  * Take the list of Notes and makes a chord out of it, if appropriate and call
  * music21.miditools.callbacks.sendOutChord callback with the Chord or Note as a parameter.
  */
-export function sendOutChord(chordNoteList: note.Note[]): note.Note|chord.Chord|undefined {
+export function sendOutChord(chordNoteList: note.Note[]): note.Note|chord.Chord {
     let appendObject;
     if (chordNoteList.length > 1) {
         // console.log(chordNoteList[0].name, chordNoteList[1].name);

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -842,29 +842,29 @@ export class Renderer {
             } else if (rendOp.staffLines === 1) {
                 // Vex.Flow.Stave.setNumLines hides all but the top line.
                 // this is better
-                vexflowStave.options.line_config = [
+                vexflowStave.setConfigForLines([
                     { visible: false },
                     { visible: false },
                     { visible: true }, // show middle
                     { visible: false },
                     { visible: false },
-                ];
+                ]);
             } else if (rendOp.staffLines === 2) {
-                vexflowStave.options.line_config = [
+                vexflowStave.setConfigForLines([
                     { visible: false },
                     { visible: false },
                     { visible: true }, // show middle
                     { visible: true },
                     { visible: false },
-                ];
+                ]);
             } else if (rendOp.staffLines === 3) {
-                vexflowStave.options.line_config = [
+                vexflowStave.setConfigForLines([
                     { visible: false },
                     { visible: true },
                     { visible: true }, // show middle
                     { visible: true },
                     { visible: false },
-                ];
+                ]);
             } else {
                 vexflowStave.setNumLines(rendOp.staffLines);
             }

--- a/tests/moduleTests/duration.ts
+++ b/tests/moduleTests/duration.ts
@@ -5,7 +5,6 @@ const { test } = QUnit;
 
 export default function tests() {
     test('music21.duration.Duration 0', assert => {
-        // @ts-ignore
         const d = new music21.duration.Duration(0.0);
         assert.equal(d.type, 'zero', 'got zero');
         assert.equal(d.dots, 0, 'got no dots');
@@ -17,7 +16,6 @@ export default function tests() {
     });
 
     test('music21.duration.Duration', assert => {
-        // @ts-ignore
         const d = new music21.duration.Duration(1.0);
         assert.equal(d.type, 'quarter', 'got quarter note from 1.0');
         assert.equal(d.dots, 0, 'got no dots');
@@ -40,17 +38,16 @@ export default function tests() {
     });
 
     test('music21.duration.Tuplet', assert => {
-        // @ts-ignore
         const d = new music21.duration.Duration(0.5);
         const t = new music21.duration.Tuplet(5, 4);
         assert.equal(t.tupletMultiplier(), 0.8, 'tuplet multiplier should be 0.8');
         d.appendTuplet(t);
         assert.equal(t.frozen, true, 'tuplet is frozen');
+
         // @ts-ignore
         assert.equal(d._tuplets[0], t, 'tuplet appended');
         assert.equal(d.quarterLength, 0.4, 'quarterLength Updated');
 
-        // @ts-ignore
         const d2 = new music21.duration.Duration(1 / 3);
         assert.equal(d2.type, 'eighth', 'got eighth note from 1/3');
         assert.equal(d2.dots, 0, 'got no dots');

--- a/tests/moduleTests/editorial.ts
+++ b/tests/moduleTests/editorial.ts
@@ -9,7 +9,7 @@ export default function tests() {
         assert.notOk(n.hasEditorialInformation, 'newly created note has no editorialInformation');
         assert.ok(n.editorial instanceof music21.editorial.Editorial);
         assert.ok(n.hasEditorialInformation);
-        const ed = n.editorial as any;
+        const ed = n.editorial;
         ed.hello = true;
         assert.ok(ed.hello);
     });

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -174,8 +174,6 @@ export default function tests() {
         assert.equal(s.highestTime, 3.0);
         assert.equal(s.duration.quarterLength, 3.0, '3 quarter QuarterLength');
 
-        // noinspection TypeScriptValidateJSTypes
-        // @ts-ignore
         s.duration = new music21.duration.Duration(3.0);
         s.append(new music21.note.Note('D#5'));
         assert.equal(

--- a/tests/moduleTests/tempo.ts
+++ b/tests/moduleTests/tempo.ts
@@ -29,7 +29,6 @@ export default function tests() {
         });
         assert.strictEqual(mark.referent.quarterLength, 2);
 
-        // @ts-ignore
         mark = new music21.tempo.MetronomeMark({
             referent: new music21.duration.Duration(2),
         });

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -148,23 +148,16 @@ export default function tests() {
         s.append(p);
         s.appendNewDOM();
         const notes_iter = p.recurse().notes;
-        const first_note = notes_iter.get(0);
-        const second_note = notes_iter.get(1);
-        // Error: Property 'pitch' does not exist on type 'NotRest'.
-        // @ts-ignore
+        const first_note = notes_iter.get(0) as music21.note.Note;
+        const second_note = notes_iter.get(1) as music21.note.Note;
         assert.equal(first_note.pitch.accidental, undefined);
-        // @ts-ignore
         assert.equal(second_note.pitch.accidental.displayStatus, true);
 
         // D -> D#
         const aug_1 = new music21.interval.Interval('A1');
-        // @ts-ignore
         first_note.pitch = aug_1.transposePitch(first_note.pitch);
         s.replaceDOM();
-        // Error: Property 'pitch' does not exist on type 'NotRest'.
-        // @ts-ignore
         assert.equal(first_note.pitch.accidental.displayStatus, true);
-        // @ts-ignore
         assert.equal(second_note.pitch.accidental.displayStatus, false);
     });
 


### PR DESCRIPTION
This allows reading and setting attributes on the Editorial object without typing it as any, making it similar to the Python version.