### PR TITLE
Update VexFlow glyph > glyphProps

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -638,7 +638,7 @@ export class Note extends NotRest {
             console.log(this.stemDirection);
         }
         if (this.stemDirection === 'noStem') {
-            vfn.glyph.stem = false;
+            vfn.glyphProps.stem = false;
             // vfn.render_options.stem_height = 0;
         } else {
             // correct VexFlow stem length for notes far from the center line;

--- a/tests/moduleTests/note.ts
+++ b/tests/moduleTests/note.ts
@@ -12,6 +12,17 @@ export default function tests() {
         assert.equal(n.pitch.octave, 5, 'Pitch octave set to 5');
     });
 
+    test('music21.note.Note.vexflowNote stems', assert => {
+        const n1 = new music21.note.Note('C');
+        const vfn1 = n1.vexflowNote();
+        assert.ok(vfn1.hasStem());
+
+        const n2 = new music21.note.Note('C');
+        n2.stemDirection = 'noStem';
+        const vfn2 = n2.vexflowNote();
+        assert.notOk(vfn2.hasStem());
+    });
+
     test('music21.note.Rest.vexflowNote whole rest', assert => {
         const r = new music21.note.Rest();
         r.duration.type = 'whole';


### PR DESCRIPTION
https://github.com/0xfe/vexflow/pull/1478 renamed `glyph` to `glyphProps`. The change was released in VexFlow v4.1.0.