### PR TITLE
Stream.noteElementFromScaledX(): handle note overlaps

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -2826,13 +2826,22 @@ export class Stream extends base.Music21Object {
             note: undefined,
         }; // a backup in case we did not find within allowablePixels
 
-        for (const el of subStream.flat.notesAndRests) {
-            const n = el as any; // for missing x and width
+        const notesAndRests = Array.from(subStream.flat.notesAndRests);
+        for (let i = 0; i < notesAndRests.length; i++) {
+            const n = notesAndRests[i] as any; // for missing x and width
+            const nextN = notesAndRests[i + 1] as any;
+            // console.log(n);
             /* should also
              * compensate for accidentals...
              */
-            const leftDistance = Math.abs(n.x - xPxScaled);
-            const rightDistance = Math.abs(n.x + n.width - xPxScaled);
+            const leftX = n.x;
+            let rightX = n.x + n.width;
+            if (nextN) {
+                // truncate notes that overflow into the following note
+                rightX = Math.min(rightX, nextN.x - 1);
+            }
+            const leftDistance = Math.abs(leftX - xPxScaled);
+            const rightDistance = Math.abs(rightX - xPxScaled);
             const minDistance = Math.min(leftDistance, rightDistance);
 
             if (

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -1092,4 +1092,31 @@ export default function tests() {
         assert.equal(empty.elements.length, 0);
         assert.equal(empty.derivation.method, 'cloneEmpty');
     });
+
+    test('music21.stream.Stream noteElementFromScaledX overlapping notes', assert => {
+        const n1 = new music21.note.Note();
+        const n2 = new music21.note.Note();
+
+        // mock Note x positions to simulate post-rendered state
+        // note widths overlap intentionally
+        (n1 as any).x = 100;
+        (n1 as any).width = 23;
+        (n2 as any).x = 120;
+        (n2 as any).width = 23;
+
+        const s = new music21.stream.Stream();
+        s.renderOptions.scaleFactor = { x: 1.0, y: 1.0 };
+        s.append([n1, n2]);
+
+        assert.deepEqual(s.noteElementFromScaledX(118), n1);
+        assert.deepEqual(s.noteElementFromScaledX(119), n1);
+        assert.deepEqual(s.noteElementFromScaledX(120), n2);
+        assert.deepEqual(s.noteElementFromScaledX(121), n2);
+
+        // even though 122 is closer to the end of n1 (123)
+        // than the beginning of n2 (120), it should still return n2
+        // since we truncate note widths that overflow into the following note
+        assert.deepEqual(s.noteElementFromScaledX(122), n2);
+        assert.deepEqual(s.noteElementFromScaledX(123), n2);
+    });
 }


### PR DESCRIPTION
Background

`Stream.noteElementFromScaledX()` returns a note `n` from the stream whose leftmost x position (`n.x`) and rightmost x position (`n.x` + `n.width`) are within `allowablePixels` of the given x position. If no note falls within this range, we select the note whose leftmost and rightmost x positions are nearest to x.

Problem

It is possible for a note's rightmost x position to overlap with the next note's leftmost position. If `n1` ends at 123 and `n2` begins at 120, then an x value of 121 will return `n2`, but 122 will return `n1`!

Solution

The current PR fixes this issue by truncating note widths so that `n1` never ends after `n2` begins.