### PR TITLE
Remove a console error

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -435,12 +435,12 @@ export const pathSimplify = path => {
     if (path.indexOf('//') === 0) {
         pPrefix = '//'; //cdn loading;
         path = path.slice(2);
-        console.log('cdn load: ', pPrefix, ' into ', path);
+        // console.log('cdn load: ', pPrefix, ' into ', path);
     } else if (path.indexOf('://') !== -1) { // for cross site requests...
         const protoSpace = path.indexOf('://');
         pPrefix = path.slice(0, protoSpace + 3);
         path = path.slice(protoSpace + 3);
-        console.log('cross-site split', pPrefix, path);
+        // console.log('cross-site split', pPrefix, path);
     }
     const ps = path.split('/');
     const addSlash = (path.slice(path.length - 1, path.length) === '/');

--- a/src/miditools.ts
+++ b/src/miditools.ts
@@ -523,7 +523,7 @@ export class MidiPlayer {
             this.player.pause(true);
         } else {
             d.src = this.pausePng();
-            this.player.resume().catch(console.error);
+            this.player.resume();
         }
     }
 


### PR DESCRIPTION
MidiPlayer.player.resume()  returns nothing (in Midicube) so cannot catch console.error

Also remove a debugging console.log from common.ts