### PR TITLE
Calculate Part estimated staff length based on longest system

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3239,20 +3239,20 @@ export class Part extends Stream {
         }
         if (!this.isFlat) {
             // part with Measures underneath
-            let totalLength = 0;
+            let currentSystemLength = 0;
             let isFirst = true;
+            const systemLengths: number[] = [];
             for (const el of this.getElementsByClass('Measure')) {
                 const m = el as Measure;
-                // this looks wrong, but actually seems to be right. moving it to
-                // after the break breaks things.
-                totalLength
-                    += m.estimateStaffLength() + m.renderOptions.staffPadding;
                 if (!isFirst && m.renderOptions.startNewSystem === true) {
-                    break;
+                    systemLengths.push(currentSystemLength);
+                    currentSystemLength = 0;
                 }
+                currentSystemLength
+                    += m.estimateStaffLength() + m.renderOptions.staffPadding;
                 isFirst = false;
             }
-            return totalLength;
+            return Math.max(...systemLengths, currentSystemLength);
         }
         // no measures found in part... treat as measure
         const tempM = new Measure();

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -1076,7 +1076,7 @@ export default function tests() {
         // Also test getting KeySignature from the context
         const previousMeasure = m.clone();
         m.remove(ks);
-        const p = new music21.stream.Score();
+        const p = new music21.stream.Part();
         p.append(previousMeasure);
         p.append(m);
         assert.equal(m.estimateStaffLength(), originalWidth + ks.width);

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -1067,22 +1067,31 @@ export default function tests() {
         v.append(n);
         const m = new music21.stream.Measure();
         m.append(v);
-        const original_width = m.estimateStaffLength();
+        const originalWidth = m.estimateStaffLength();
         const ks = new music21.key.KeySignature(-6);
         m.append(ks);
         m.renderOptions.displayKeySignature = true;
-        assert.equal(m.estimateStaffLength(), original_width + ks.width);
+        assert.equal(m.estimateStaffLength(), originalWidth + ks.width);
 
         // Also test getting KeySignature from the context
-        const previous_measure = m.clone();
+        const previousMeasure = m.clone();
         m.remove(ks);
-        const p = new music21.stream.Part();
-        p.append(previous_measure);
+        const p = new music21.stream.Score();
+        p.append(previousMeasure);
         p.append(m);
-        assert.equal(m.estimateStaffLength(), original_width + ks.width);
+        assert.equal(m.estimateStaffLength(), originalWidth + ks.width);
 
         n.lyric = 'lorem';  // (7px * 5 letters + 2) = 37, original width otherwise starts at 30
-        assert.equal(m.estimateStaffLength(), original_width + 7 + ks.width);
+        assert.equal(m.estimateStaffLength(), originalWidth + 7 + ks.width);
+
+        const previousMeasureOverallLength =
+            previousMeasure.estimateStaffLength() + previousMeasure.renderOptions.staffPadding;
+        const measureOverallLength = m.estimateStaffLength() + m.renderOptions.staffPadding;
+        assert.equal(p.estimateStaffLength(), previousMeasureOverallLength + measureOverallLength);
+
+        m.renderOptions.startNewSystem = true;
+        assert.ok(previousMeasureOverallLength < measureOverallLength);
+        assert.equal(p.estimateStaffLength(), measureOverallLength);
     });
 
     test('music21.stream.Stream cloneEmpty', assert => {


### PR DESCRIPTION
`Part.estimateStaffLength()` calculates the staff length by incrementing measure lengths until reaching a measure with `startNewSystem`, at which point it exits. The problem with this approach is that different systems can have different estimated lengths, so any system that is longer than the first one will appear visually to be truncated when the Part is rendered to the DOM.

This PR instead calculates the lengths of all systems and then selects the longest length as the estimated length of the Part as a whole.

Small note for those who are curious: previously, when calculating the length of the first system we also included the length the first measure that appeared _after_ the system break (i.e. the measure with `startNewSystem`). This seemed wrong, but was in fact necessary as it ensured that most subsequent parts did not get truncated despite the issue outlined above. (See a comment in the old code: `this looks wrong, but actually seems to be right. moving it to after the break breaks things.`) This hack is no longer necessary, so we now exit right at the system break like you would expect.