### PR TITLE
Prevent getBeams() from creating single stop beam

### DIFF
--- a/src/meter.ts
+++ b/src/meter.ts
@@ -350,7 +350,7 @@ export class TimeSignature extends base.Music21Object {
                 beamType = 'stop';
                 if (beamPrevious === undefined || !beamPrevious.getNumbers().includes(beamNumber)) {
                     beamType = 'partial-left';
-                } else if (beamPrevious && beamPrevious.getTypeByNumber(beamNumber) === 'stop') {
+                } else if (beamPrevious && ['stop', 'partial-left'].includes(beamPrevious.getTypeByNumber(beamNumber))) {
                     beamsList[i] = undefined;
                 }
             } else if (beamPrevious === undefined || !beamPrevious.getNumbers().includes(beamNumber)) {

--- a/src/meter.ts
+++ b/src/meter.ts
@@ -350,7 +350,10 @@ export class TimeSignature extends base.Music21Object {
                 beamType = 'stop';
                 if (beamPrevious === undefined || !beamPrevious.getNumbers().includes(beamNumber)) {
                     beamType = 'partial-left';
-                } else if (beamPrevious && ['stop', 'partial-left'].includes(beamPrevious.getTypeByNumber(beamNumber))) {
+                } else if (
+                    beamPrevious
+                    && ['stop', 'partial-left'].includes(beamPrevious.getTypeByNumber(beamNumber))
+                ) {
                     beamsList[i] = undefined;
                 }
             } else if (beamPrevious === undefined || !beamPrevious.getNumbers().includes(beamNumber)) {

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -666,8 +666,10 @@ export class Renderer {
                         activeBeamGroupNotes.push(n.activeVexflowNote);
                     }
                     if (eighthNoteBeam.type === 'stop') {
-                        const vfBeam = new VFBeam(activeBeamGroupNotes, false);
-                        this.beamGroups.push(vfBeam);
+                        if (activeBeamGroupNotes.length > 1) {
+                            const vfBeam = new VFBeam(activeBeamGroupNotes, false);
+                            this.beamGroups.push(vfBeam);
+                        }
                         activeBeamGroupNotes = [];
                     }
                 }

--- a/tests/moduleTests/meter.ts
+++ b/tests/moduleTests/meter.ts
@@ -202,6 +202,26 @@ export default function tests() {
         assert.strictEqual(typeof beamsList[5], 'undefined');
     });
 
+    test('music21.meter.TimeSignature getBeams singleton stop beams', assert => {
+        // This tests a very specific situation where the penultimate note in a measure:
+        //   1. is beamable
+        //   2. is held across a beat
+        //   3. is preceded by a non-beamable note
+        //   4. is followed by a beamable note
+        // Previously this situation would result in a single 'stop' beam at the final note
+        // and no others.
+        const m = new music21.stream.Measure();
+        m.append(new music21.note.Note('C', 0.5));
+        m.append(new music21.note.Note('C', 1.0));
+        m.append(new music21.note.Note('C', 0.75));
+        m.append(new music21.note.Note('C', 0.75));
+
+        const ts = new music21.meter.TimeSignature('3/4');
+        const beamsList = ts.getBeams(m);
+        assert.strictEqual(typeof beamsList[2], 'undefined');
+        assert.strictEqual(typeof beamsList[3], 'undefined');
+    });
+
     test('music21.meter.TimeSignature compound', assert => {
         const m = new music21.meter.TimeSignature('6/8');
 


### PR DESCRIPTION
We have a very specific situation where `TimeSignature.getBeams()` can product a single 'stop' beam at the final note and no others. This happens when the penultimate note in a measure:
1. is beamable
2. is held across a beat
3. is preceded by a non-beamable note
4. is followed by a beamable note

This PR updates `getBeams()` to acccount for this case, and `Renderer.formatVoiceGroup()` to ensure that errors like this do not happen again.

---

<img width="626" alt="Screen Shot 2023-10-16 at 6 23 05 AM" src="https://github.com/cuthbertLab/music21j/assets/22668138/964bcad6-7976-4064-9cf6-46ef87a06ef8">

```javascript
const s = new music21.stream.Measure();
s.autoBeam = true;
s.renderOptions.useVexflowAutobeam = false;
s.append(new music21.meter.TimeSignature('3/4'));
for (const ql of [0.5, 1.0, 0.75, 0.75]) {
    const n = new music21.note.Note('C#', ql);
    s.append(n);
}
s.replaceDOM();
```
