### PR TITLE
Proper typing for getElementsByClass

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,6 +51,7 @@
         "no-console": ["off"],
         "no-continue": ["off"],
         "no-confusing-arrow": ["off"],
+        "no-dupe-class-members": ["off"],
         "no-else-return": ["off"],
         "no-lonely-if": ["off"],
         "no-mixed-operators": ["off"],

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -10,7 +10,6 @@
  */
 import * as base from './base';
 import * as pitch from './pitch';
-import type * as note from './note';
 import type { Stream } from './stream';
 
 /*  music21.Clef
@@ -317,25 +316,19 @@ export function bestClef(st: Stream, { recurse=true }={}): Clef {
     } else {
         stFlat = st;
     }
-    let totalNotes = 0;
-    let totalPitch = 0.0;
-    for (let i = 0; i < stFlat.length; i++) {
-        const el = stFlat.get(i);
-        if ((<note.Note><any> el).pitch !== undefined) {
-            totalNotes += 1;
-            totalPitch += (<note.Note><any> el).pitch.diatonicNoteNum;
-        } else if ((<note.NotRest><any> el).pitches !== undefined) {
-            for (let j = 0; j < (<note.NotRest><any> el).pitches.length; j++) {
-                totalNotes += 1;
-                totalPitch += (<note.NotRest><any> el).pitches[j].diatonicNoteNum;
-            }
+    let totalPitches = 0;
+    let totalDNN = 0.0;
+    for (const n of stFlat.notes) {
+        for (const p of n.pitches) {
+            totalPitches += 1;
+            totalDNN += p.diatonicNoteNum;
         }
     }
     let averageHeight: number;
-    if (totalNotes === 0) {
+    if (totalPitches === 0) {
         averageHeight = 29;
     } else {
-        averageHeight = totalPitch / totalNotes;
+        averageHeight = totalDNN / totalPitches;
     }
     // console.log('bestClef: average height', averageHeight);
     if (averageHeight > 28) {

--- a/src/note.ts
+++ b/src/note.ts
@@ -103,7 +103,7 @@ export class Lyric extends prebase.ProtoM21Object {
     protected _identifier: string|number;
     syllabic: string;
     applyRaw: boolean;
-    style;
+    style: Record<string, any>;
 
     constructor(
         text: string,
@@ -245,6 +245,15 @@ export class GeneralNote extends base.Music21Object {
         /* Later: augmentOrDiminish, getGrace, */
     }
 
+    get pitches(): pitch.Pitch[] {
+        return [];
+    }
+
+    set pitches(_value: pitch.Pitch[]) {
+        // purposely does nothing
+    }
+
+
     get lyric() {
         if (this.lyrics.length > 0) {
             return this.lyrics[0].text;
@@ -330,7 +339,7 @@ export class GeneralNote extends base.Music21Object {
     /**
      * For subclassing.  Do not use this...
      */
-    vexflowNote(options): VFStaveNote {
+    vexflowNote(_options): VFStaveNote {
         return new VFStaveNote({
             keys: [],
             duration: this.duration.vexflowDuration + 'r',
@@ -353,7 +362,7 @@ export class GeneralNote extends base.Music21Object {
      *
      * options -- a set of VexFlow options
      */
-    vexflowAccidentalsAndDisplay(vfn: VFStaveNote, options={}): void {
+    vexflowAccidentalsAndDisplay(vfn: VFStaveNote, _options={}): void {
         if (this.duration.dots > 0) {
             for (let i = 0; i < this.duration.dots; i++) {
                 VFDot.buildAndAttach([vfn], { all: true });
@@ -388,11 +397,7 @@ export class GeneralNote extends base.Music21Object {
     playMidi(
         tempo: number = 120,
         _nextElement: base.Music21Object = undefined,
-        {
-            instrument=undefined,
-            channel=undefined,
-            playLegato=false,
-        }: {
+        _unused_options: {
             instrument?: instrument.Instrument,
             channel?: number,
             playLegato?: boolean,
@@ -430,15 +435,6 @@ export class NotRest extends GeneralNote {
         /* TODO: this.duration.linkage -- need durationUnits */
         /* TODO: check notehead, noteheadFill, noteheadParentheses */
     }
-
-    get pitches(): pitch.Pitch[] {
-        return [];
-    }
-
-    set pitches(_value: pitch.Pitch[]) {
-        // purposely does nothing
-    }
-
 
     get stemDirection() {
         return this._stemDirection;
@@ -761,7 +757,7 @@ export class Rest extends GeneralNote {
      * Corrects for bug in VexFlow that renders a whole rest too low.
      *
      */
-    override vexflowNote(options): VFStaveNote {
+    override vexflowNote(_options): VFStaveNote {
         let keyLine = 'b/4';
         const activeSiteSingleLine = (
             this.activeSite !== undefined

--- a/src/prebase.ts
+++ b/src/prebase.ts
@@ -174,8 +174,6 @@ export class ProtoM21Object {
     /**
      * Check to see if an object is of this class or subclass.
      *
-     * @param {string|string[]} testClass - a class or Array of classes to test
-     * @returns {boolean}
      * @example
      * var n = new music21.note.Note();
      * n.isClassOrSubclass('Note'); // true
@@ -185,13 +183,13 @@ export class ProtoM21Object {
      * n.isClassOrSubclass(['Duration', 'NotRest']); // true // NotRest
      */
     isClassOrSubclass(
-        testClass: string|typeof ProtoM21Object|(string | typeof ProtoM21Object)[]
+        testClass: string|string[]|(new () => ProtoM21Object)|(new () => ProtoM21Object)[]
     ): boolean {
-        let useTestClass: (string | typeof ProtoM21Object)[];
+        let useTestClass: string[] | (new () => ProtoM21Object)[];
         if (!(testClass instanceof Array)) {
-            useTestClass = [testClass] as (string | typeof ProtoM21Object)[];
+            useTestClass = [testClass] as string[] | (new () => ProtoM21Object)[];
         } else {
-            useTestClass = testClass as (string | typeof ProtoM21Object)[];
+            useTestClass = testClass as string[] | (new () => ProtoM21Object)[];
         }
         for (const thisTestClass of useTestClass) {
             if (this.classSet.has(thisTestClass)) {
@@ -201,11 +199,7 @@ export class ProtoM21Object {
         return false;
     }
 
-    /**
-     *
-     * @returns {string}
-     */
-    toString() {
+    toString(): string {
         let si = this.stringInfo();
         if (si !== '') {
             si = ' ' + si;
@@ -213,11 +207,7 @@ export class ProtoM21Object {
         return `<${this.classes[0]}${si}>`;
     }
 
-    /**
-     *
-     * @returns {string}
-     */
-    stringInfo() {
+    stringInfo(): string {
         return '';
     }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -49,6 +49,7 @@ import * as makeNotation from './stream/makeNotation';
 import type { KeySignature } from './key';
 import defaults from './defaults';
 import {to_el} from './common';
+import {ClassFilterType} from './types';
 
 export { filters };
 export { iterator };
@@ -393,12 +394,12 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
     }
 
     get notes(): iterator.StreamIterator<note.NotRest> {
-        return this.getElementsByClass(['Note', 'Chord']) as
+        return this.getElementsByClass(note.NotRest) as
             iterator.StreamIterator<note.NotRest>;
     }
 
     get notesAndRests(): iterator.StreamIterator<note.GeneralNote> {
-        return this.getElementsByClass('GeneralNote') as iterator.StreamIterator<note.GeneralNote>;
+        return this.getElementsByClass(note.GeneralNote) as iterator.StreamIterator<note.GeneralNote>;
     }
 
     get tempo(): number {
@@ -1611,11 +1612,23 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
     /**
      * Find all elements with a certain class; if an Array is given, then any
      * matching class will work.
-     *
-     * @param {string[]|string} classList - a list of classes to find
      */
-    getElementsByClass(classList: string|string[]): iterator.StreamIterator {
-        return this.iter.getElementsByClass(classList);
+    getElementsByClass<TT extends base.Music21Object = base.Music21Object>
+        (classList: new() => TT): iterator.StreamIterator<TT>;
+
+    getElementsByClass<TT extends base.Music21Object = base.Music21Object>
+        (classList: string): iterator.StreamIterator<TT>;
+
+    getElementsByClass<TT extends base.Music21Object = base.Music21Object>
+        (classList: string[]): iterator.StreamIterator<TT>;
+
+    getElementsByClass<TT extends base.Music21Object = base.Music21Object>
+        (classList: (new() => base.Music21Object)[]): iterator.StreamIterator<TT>;
+
+    getElementsByClass<TT extends base.Music21Object = base.Music21Object
+    >(classList: ClassFilterType): iterator.StreamIterator<TT>
+    {
+        return this.iter.getElementsByClass(classList) as iterator.StreamIterator<TT>;
     }
 
     /**
@@ -1786,7 +1799,7 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
         pitchPastMeasure=[],
         useKeySignature=true,
         alteredPitches=[],
-        searchKeySignatureByContext=false,  // not yet used.
+        // searchKeySignatureByContext=false,
         cautionaryPitchClass=true,
         cautionaryAll=false,
         inPlace=false,
@@ -1924,7 +1937,7 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
 
     //  * *********  VexFlow functionality
 
-    write(format='musicxml'): string {
+    write(_format='musicxml'): string {
         return _exportMusicXMLAsText(this);
     }
 
@@ -2148,7 +2161,7 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
         let nLast: note.GeneralNote;
         let iLast: number;
 
-        const updateEndMatch = nInner => {
+        const updateEndMatch = (nInner: note.GeneralNote): boolean => {
             const ni_is_chord = nInner.classes.includes('Chord');
             const nLast_is_chord = nLast?.classes.includes('Chord');
 
@@ -2164,7 +2177,7 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
                 && nLast
                 && posConnected.includes(iLast)
                 && !nLast_is_chord
-                && (nLast as note.Note).pitch?.eq(nInner.pitch)
+                && (nLast as note.Note).pitch?.eq((nInner as note.Note).pitch)
             ) {
                 return true;
             }

--- a/src/stream/filters.ts
+++ b/src/stream/filters.ts
@@ -84,13 +84,13 @@ export class ClassFilter extends StreamFilter {
         return 'getElementsByClass';
     }
 
-    classList: string[]|(typeof Music21Object)[];
+    classList: string[]|(new() => Music21Object)[];
 
     constructor(classList: ClassFilterType = []) {
         super();
-        let classListArray: string[]|typeof Music21Object[];
+        let classListArray: string[]|(new() => Music21Object)[];
         if (!Array.isArray(classList)) {
-            classListArray = <string[]|(typeof Music21Object)[]> [classList];
+            classListArray = <string[]|(new() => Music21Object)[]> [classList];
         } else {
             classListArray = classList;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type {Music21Object} from './base';
 
-export type ClassFilterType = string|string[]|typeof Music21Object|(typeof Music21Object)[]
+// note: mixing both string and types in a list is not supported.
+export type ClassFilterType = string|string[]|(new() => Music21Object)|(new() => Music21Object)[]
 
 export enum StaveConnector {
     SINGLE = 'single',

--- a/tests/moduleTests/clef.ts
+++ b/tests/moduleTests/clef.ts
@@ -41,4 +41,19 @@ export default function tests() {
         const bc = music21.clef.clefFromString('F4');
         assert.ok(bc.isClassOrSubclass('BassClef'), 'bc is BassClef');
     });
+    test('music21.clef bestClef', assert => {
+        const s = new music21.stream.Stream();
+        s.append(new music21.note.Note('C5'));
+        assert.ok(music21.clef.bestClef(s).isClassOrSubclass('TrebleClef'), 'best clef is treble');
+        s.append(new music21.chord.Chord(['C2', 'E2', 'G2']));
+        assert.ok(music21.clef.bestClef(s).isClassOrSubclass('BassClef'), 'best clef is bass');
+        const m = new music21.stream.Measure();
+        m.append(new music21.chord.Chord(['E7', 'F7', 'G7', 'A7', 'B7', 'C8']));
+        s.append(m);
+        assert.ok(music21.clef.bestClef(s).isClassOrSubclass('TrebleClef'), 'best clef is treble');
+        assert.ok(
+            music21.clef.bestClef(s, {recurse: false}).isClassOrSubclass('BassClef'),
+            'best clef is bass'
+        );
+    });
 }

--- a/tests/moduleTests/prebase.ts
+++ b/tests/moduleTests/prebase.ts
@@ -21,7 +21,7 @@ export default function tests() {
         assert.ok(n.isClassOrSubclass('GeneralNote'));
         assert.ok(n.isClassOrSubclass('music21.note.Note'));
         assert.ok(n.isClassOrSubclass(music21.note.Note));
-        assert.ok(n.isClassOrSubclass(['Rest', music21.note.Note]));
+        assert.ok(n.isClassOrSubclass([music21.note.Rest, music21.note.Note]));
         assert.notOk(n.isClassOrSubclass('Rest'));
     });
     test('music21.prebase.ProtoM21Object.classSet', assert => {


### PR DESCRIPTION
not yet implemented for recurse()...

When getElementsByClass is passed a single Music21 class, like m21p, now the elements of the StreamIterator will be properly typed.

Note that it does not yet work on recurse() -- I want to make sure that even this change doesn't break my projects first.

.pitches is moved from NotRest to GeneralNote to match recent changes in m21p.

Mixing strings and M21Object classes in lists to getElements calls is no longer allowed.  Choose one or the other.

turn off eslint checking for dup methods.  Typescript checks this for us, and eslint does not know about overload methods.

rewrite clef.bestClef with modern looping techniques, and taking advantage of the automatic typing.  Add test, including recurse test.