### PR TITLE
Stream.getElementsByOffset() should return clone

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1661,7 +1661,7 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
     //    }
 
     /**
-     * Returns a new stream [StreamIterator does not yet exist in music21j]
+     * Returns a new StreamIterator
      * containing all Music21Objects that are found at a certain offset or
      * within a certain offset time range (given the offsetStart and
      * (optional) offsetEnd values).
@@ -1678,7 +1678,7 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
             includeElementsThatEndAtStart=true,
             classList=undefined,
         }={}
-    ) {
+    ): iterator.StreamIterator {
 
         let s: iterator.StreamIterator;
         if (classList !== undefined) {
@@ -1686,7 +1686,7 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
         } else {
             s = this.iter;
         }
-        s.getElementsByOffset(
+        return s.getElementsByOffset(
             offsetStart,
             offsetEnd,
             {
@@ -1696,7 +1696,6 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
                 includeElementsThatEndAtStart,
             }
         );
-        return s;
     }
 
     /**

--- a/src/stream/iterator.ts
+++ b/src/stream/iterator.ts
@@ -228,7 +228,7 @@ export class StreamIteratorBase<T extends Music21Object = Music21Object> {
     /**
      * Returns a new StreamIterator with the filter removed.
      *
-     * Silently ignres
+     * Silently ignores
      */
     removeFilter(oldFilter: filters.StreamFilter): StreamIteratorBase<T> {
         const index = this.filters.indexOf(oldFilter);

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -446,6 +446,19 @@ export default function tests() {
         c = s.getElementsByClass('GeneralNote');
         assert.equal(c.length, 3, 'got multiple subclasses');
     });
+    test('music21.stream.Stream.getElementsByOffset', assert => {
+        const s = new music21.stream.Stream();
+        const n1 = new music21.note.Note('C#5', 1.0);
+        const n2 = new music21.note.Note('D#5', 1.0);
+        s.append(n1);
+        s.append(n2);
+        const elements_at_0 = Array.from(s.getElementsByOffset(0.0));
+        const elements_at_1 = Array.from(s.getElementsByOffset(1.0));
+        assert.ok(elements_at_0.includes(n1), 'n1 is at 0.0');
+        assert.ok(elements_at_1.includes(n2), 'n2 is at 1.0');
+        assert.notOk(elements_at_0.includes(n2), 'n2 is not at 0.0');
+        assert.notOk(elements_at_1.includes(n1), 'n1 is not at 1.0');
+    });
     test('music21.stream.offsetMap', assert => {
         const n = new music21.note.Note('G3');
         const o = new music21.note.Note('A3');


### PR DESCRIPTION
Bug

`Stream.getElementsByOffset()` was returning an iterator without the offset filter added.

Fix

With https://github.com/cuthbertLab/music21j/pull/239, `addFilter()` now returns a clone of the original iterator. This PR rewrites `Stream.getElementsByOffset()` to return the clone, not the original.