### PR TITLE
Lyrics as Vexflow annotations

### DIFF
--- a/src/chord.ts
+++ b/src/chord.ts
@@ -20,6 +20,7 @@ import * as chordTables from './chordTables';
 import type * as clef from './clef';
 import type * as instrument from './instrument';
 import type * as pitch from './pitch';
+import {VexflowNoteOptions} from './note';
 
 export { chordTables };
 
@@ -127,9 +128,9 @@ export class Chord extends note.NotRest {
         this._overrides = {};
     }
 
-    vexflowNote({ clef=undefined }={}): VFStaveNote {
+    vexflowNote(options: VexflowNoteOptions = {}): VFStaveNote {
         this.sortPitches();
-        return super.vexflowNote({ clef });
+        return super.vexflowNote(options);
     }
 
     get orderedPitchClasses(): number[] {

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,7 @@ import * as svgs from './svgs';
 import * as tempo from './tempo';
 import * as tie from './tie';
 import * as tinyNotation from './tinyNotation';
+import * as vfShims from './vfShims';
 import * as vfShow from './vfShow';
 import * as voiceLeading from './voiceLeading';
 import * as webmidi from './webmidi';
@@ -135,6 +136,7 @@ export {
     tempo,
     tie,
     tinyNotation,
+    vfShims,
     vfShow,
     voiceLeading,
     webmidi,

--- a/src/renderOptions.ts
+++ b/src/renderOptions.ts
@@ -48,6 +48,8 @@ export class RenderOptions {
     // additional padding at the bottom of the stream
     // (not every system).
     marginBottom: number = 0;
+    lyricsLine: number = -3;
+    adjustMarginBottomForLyrics: boolean = true;  // not yet implemented.
 
     systemIndex: number = 0;
     partIndex: number = 0;

--- a/src/vfShims.ts
+++ b/src/vfShims.ts
@@ -1,0 +1,191 @@
+/**
+ * music21j -- Javascript reimplementation of Core music21p features.
+ * Copyright (c) 2013-24, Michael Scott Asato Cuthbert
+ * Based on music21 (music21p), Copyright (c) 2006-24, Michael Scott Asato Cuthbert
+ *
+ * The infamous vfShims returns!  To fix things that Vexflow makes hard to fix!
+ */
+
+import {
+    Annotation,
+    AnnotationHorizontalJustify, isStemmableNote, isTabNote,
+    log,
+    type ModifierContextState,
+    ModifierPosition, Stave, Stem,
+    type StemmableNote,
+    TextFormatter,
+} from 'vexflow';
+
+// eslint-disable-next-line
+function L(...args: any[]) {
+    if (VFLyricAnnotation.DEBUG) {
+        log('Vex.Flow.Annotation', args);
+    }
+}
+
+const original_Annotation_format = Annotation.format;
+Annotation.format = function format(annotations: Annotation[], state: ModifierContextState): boolean {
+    if (!annotations || annotations.length === 0) {
+        return false;
+    }
+    if (!(annotations[0] instanceof VFLyricAnnotation)) {
+        return original_Annotation_format.bind(this)(annotations, state);
+    }
+    return VFLyricAnnotation.format.bind(this)(annotations as VFLyricAnnotation[], state);
+};
+Annotation.format = Annotation.format.bind(Annotation);
+
+
+export class VFLyricAnnotation extends Annotation {
+    static DEBUG = true;
+
+    static format(annotations: VFLyricAnnotation[], state: ModifierContextState): boolean {
+        if (!annotations || annotations.length === 0) {
+            return false;
+        }
+        let leftWidth = 0;
+        let rightWidth = 0;
+        let maxLeftGlyphWidth = 0;
+        let maxRightGlyphWidth = 0;
+        for (let i = 0; i < annotations.length; ++i) {
+            const annotation = annotations[i];
+            const textFormatter = TextFormatter.create(annotation.textFont);
+            // Text height is expressed in fractional stave spaces.
+            const textLines = (2 + textFormatter.getYForStringInPx(annotation.text).height) / 10;
+            let verticalSpaceNeeded = textLines;
+
+            const note = annotation.checkAttachedNote();
+            const glyphWidth = note.getGlyphProps().getWidth();
+            // Get the text width from the font metrics.
+            const textWidth = textFormatter.getWidthForTextInPx(annotation.text);
+            if (annotation.horizontalJustification === AnnotationHorizontalJustify.LEFT) {
+                maxLeftGlyphWidth = Math.max(glyphWidth, maxLeftGlyphWidth);
+                leftWidth = Math.max(leftWidth, textWidth) + Annotation.minAnnotationPadding;
+            } else if (annotation.horizontalJustification === AnnotationHorizontalJustify.RIGHT) {
+                maxRightGlyphWidth = Math.max(glyphWidth, maxRightGlyphWidth);
+                rightWidth = Math.max(rightWidth, textWidth);
+            } else {
+                leftWidth = Math.max(leftWidth, textWidth / 2) + Annotation.minAnnotationPadding;
+                rightWidth = Math.max(rightWidth, textWidth / 2);
+                maxLeftGlyphWidth = Math.max(glyphWidth / 2, maxLeftGlyphWidth);
+                maxRightGlyphWidth = Math.max(glyphWidth / 2, maxRightGlyphWidth);
+            }
+
+            const stave: Stave | undefined = note.getStave();
+            const stemDirection = note.hasStem() ? note.getStemDirection() : Stem.UP;
+            let stemHeight = 0;
+            let lines = 5;
+
+            if (isTabNote(note)) {
+                if (note.render_options.draw_stem) {
+                    const stem = (note as StemmableNote).getStem();
+                    if (stem) {
+                        stemHeight = Math.abs(stem.getHeight()) / 10;
+                    }
+                } else {
+                    stemHeight = 0;
+                }
+            } else if (isStemmableNote(note)) {
+                const stem = note.getStem();
+                if (stem && note.getNoteType() === 'n') {
+                    stemHeight = Math.abs(stem.getHeight()) / 10;
+                }
+            }
+            if (stave) {
+                lines = stave.getNumLines();
+            }
+
+            if (annotation.verticalJustification === this.VerticalJustify.TOP) {
+                let noteLine = note.getLineNumber(true);
+                if (isTabNote(note)) {
+                    noteLine = lines - (note.leastString() - 0.5);
+                }
+                if (stemDirection === Stem.UP) {
+                    noteLine += stemHeight;
+                }
+                const curTop = noteLine + state.top_text_line + 0.5;
+                if (curTop < lines) {
+                    // annotation.setTextLine(lines - noteLine);
+                    verticalSpaceNeeded += lines - noteLine;
+                    state.top_text_line = verticalSpaceNeeded;
+                } else {
+                    // annotation.setTextLine(state.top_text_line);
+                    state.top_text_line += verticalSpaceNeeded;
+                }
+            } else if (annotation.verticalJustification === this.VerticalJustify.BOTTOM) {
+                let noteLine = lines - note.getLineNumber();
+                if (isTabNote(note)) {
+                    noteLine = note.greatestString() - 1;
+                }
+                if (stemDirection === Stem.DOWN) {
+                    noteLine += stemHeight;
+                }
+                const curBottom = noteLine + state.text_line + 1;
+                if (curBottom < lines) {
+                    // annotation.setTextLine(lines - curBottom);
+                    verticalSpaceNeeded += lines - curBottom;
+                    state.text_line = verticalSpaceNeeded;
+                } else {
+                    // annotation.setTextLine(state.text_line);
+                    state.text_line += verticalSpaceNeeded;
+                }
+            } else {
+                // annotation.setTextLine(state.text_line);
+            }
+        }
+        const rightOverlap = Math.min(
+            Math.max(rightWidth - maxRightGlyphWidth, 0),
+            Math.max(rightWidth - state.right_shift, 0)
+        );
+        const leftOverlap = Math.min(
+            Math.max(leftWidth - maxLeftGlyphWidth, 0),
+            Math.max(leftWidth - state.left_shift, 0)
+        );
+        state.left_shift += leftOverlap;
+        state.right_shift += rightOverlap;
+        return true;
+    }
+
+    /** Render text below the note at the given staff line */
+    draw(): void {
+        L('text_line 1', this.text_line);
+        const ctx = this.checkContext();
+        const note = this.checkAttachedNote();
+        const textFormatter = TextFormatter.create(this.textFont);
+        const start_x = note.getModifierStartXY(ModifierPosition.ABOVE, this.index).x;
+
+        this.setRendered();
+
+        // We're changing context parameters. Save current state.
+        ctx.save();
+        // Apply style might not save context, if this.style is undefined, so we
+        // still need to save context state just before this, since we will be
+        // changing ctx parameters below.
+        this.applyStyle();
+        ctx.openGroup('annotation', this.getAttribute('id'));
+        ctx.setFont(this.textFont);
+
+        const text_width = textFormatter.getWidthForTextInPx(this.text);
+        let x: number;
+
+        if (this.horizontalJustification === AnnotationHorizontalJustify.LEFT) {
+            x = start_x;
+        } else if (this.horizontalJustification === AnnotationHorizontalJustify.RIGHT) {
+            x = start_x - text_width;
+        } else if (this.horizontalJustification === AnnotationHorizontalJustify.CENTER) {
+            x = start_x - text_width / 2;
+        } /* CENTER_STEM */ else {
+            x = (note as StemmableNote).getStemX() - text_width / 2;
+        }
+
+        const stave = note.checkStave();
+        L('text_line', this.text_line);
+        const y = stave.getYForLine(this.text_line);
+
+        L('Rendering annotation: ', this.text, x, y);
+        ctx.fillText(this.text, x, y);
+        ctx.closeGroup();
+        this.restoreStyle();
+        ctx.restore();
+    }
+}

--- a/src/vfShims.ts
+++ b/src/vfShims.ts
@@ -37,7 +37,7 @@ Annotation.format = Annotation.format.bind(Annotation);
 
 
 export class VFLyricAnnotation extends Annotation {
-    static DEBUG = true;
+    static DEBUG = false;
 
     static format(annotations: VFLyricAnnotation[], state: ModifierContextState): boolean {
         if (!annotations || annotations.length === 0) {
@@ -83,7 +83,6 @@ export class VFLyricAnnotation extends Annotation {
 
     /** Render text below the note at the given staff line */
     draw(): void {
-        L('text_line 1', this.text_line);
         const ctx = this.checkContext();
         const note = this.checkAttachedNote();
         const textFormatter = TextFormatter.create(this.textFont);
@@ -114,7 +113,6 @@ export class VFLyricAnnotation extends Annotation {
         }
 
         const stave = note.checkStave();
-        L('text_line', this.text_line);
         const y = stave.getYForLine(this.text_line);
 
         L('Rendering annotation: ', this.text, x, y);

--- a/src/vfShims.ts
+++ b/src/vfShims.ts
@@ -8,10 +8,10 @@
 
 import {
     Annotation,
-    AnnotationHorizontalJustify, isStemmableNote, isTabNote,
+    AnnotationHorizontalJustify,
     log,
     type ModifierContextState,
-    ModifierPosition, Stave, Stem,
+    ModifierPosition,
     type StemmableNote,
     TextFormatter,
 } from 'vexflow';
@@ -50,9 +50,6 @@ export class VFLyricAnnotation extends Annotation {
         for (let i = 0; i < annotations.length; ++i) {
             const annotation = annotations[i];
             const textFormatter = TextFormatter.create(annotation.textFont);
-            // Text height is expressed in fractional stave spaces.
-            const textLines = (2 + textFormatter.getYForStringInPx(annotation.text).height) / 10;
-            let verticalSpaceNeeded = textLines;
 
             const note = annotation.checkAttachedNote();
             const glyphWidth = note.getGlyphProps().getWidth();
@@ -69,68 +66,6 @@ export class VFLyricAnnotation extends Annotation {
                 rightWidth = Math.max(rightWidth, textWidth / 2);
                 maxLeftGlyphWidth = Math.max(glyphWidth / 2, maxLeftGlyphWidth);
                 maxRightGlyphWidth = Math.max(glyphWidth / 2, maxRightGlyphWidth);
-            }
-
-            const stave: Stave | undefined = note.getStave();
-            const stemDirection = note.hasStem() ? note.getStemDirection() : Stem.UP;
-            let stemHeight = 0;
-            let lines = 5;
-
-            if (isTabNote(note)) {
-                if (note.render_options.draw_stem) {
-                    const stem = (note as StemmableNote).getStem();
-                    if (stem) {
-                        stemHeight = Math.abs(stem.getHeight()) / 10;
-                    }
-                } else {
-                    stemHeight = 0;
-                }
-            } else if (isStemmableNote(note)) {
-                const stem = note.getStem();
-                if (stem && note.getNoteType() === 'n') {
-                    stemHeight = Math.abs(stem.getHeight()) / 10;
-                }
-            }
-            if (stave) {
-                lines = stave.getNumLines();
-            }
-
-            if (annotation.verticalJustification === this.VerticalJustify.TOP) {
-                let noteLine = note.getLineNumber(true);
-                if (isTabNote(note)) {
-                    noteLine = lines - (note.leastString() - 0.5);
-                }
-                if (stemDirection === Stem.UP) {
-                    noteLine += stemHeight;
-                }
-                const curTop = noteLine + state.top_text_line + 0.5;
-                if (curTop < lines) {
-                    // annotation.setTextLine(lines - noteLine);
-                    verticalSpaceNeeded += lines - noteLine;
-                    state.top_text_line = verticalSpaceNeeded;
-                } else {
-                    // annotation.setTextLine(state.top_text_line);
-                    state.top_text_line += verticalSpaceNeeded;
-                }
-            } else if (annotation.verticalJustification === this.VerticalJustify.BOTTOM) {
-                let noteLine = lines - note.getLineNumber();
-                if (isTabNote(note)) {
-                    noteLine = note.greatestString() - 1;
-                }
-                if (stemDirection === Stem.DOWN) {
-                    noteLine += stemHeight;
-                }
-                const curBottom = noteLine + state.text_line + 1;
-                if (curBottom < lines) {
-                    // annotation.setTextLine(lines - curBottom);
-                    verticalSpaceNeeded += lines - curBottom;
-                    state.text_line = verticalSpaceNeeded;
-                } else {
-                    // annotation.setTextLine(state.text_line);
-                    state.text_line += verticalSpaceNeeded;
-                }
-            } else {
-                // annotation.setTextLine(state.text_line);
             }
         }
         const rightOverlap = Math.min(

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -15,14 +15,14 @@ import {
     Stave as VFStave, StaveConnector as VFStaveConnector,
     type StaveConnectorType as VFStaveConnectorType,
     StaveNote as VFStaveNote,
-    StaveTie as VFStaveTie, SVGContext as VFSVGContext, TextNote as VFTextNote,
+    StaveTie as VFStaveTie, SVGContext as VFSVGContext, // TextNote as VFTextNote,
     Tuplet as VFTuplet, Voice as VFVoice,
 } from 'vexflow';
-import type {FontInfo as VFFontInfo} from 'vexflow/src/font';
+// import type {FontInfo as VFFontInfo} from 'vexflow/src/font';
 
 import { debug } from './debug';
 import * as clef from './clef';
-import * as duration from './duration';
+// import * as duration from './duration';
 import * as stream from './stream';  // this is able to be imported fine.
 
 import {coerceHTMLElement} from './common';
@@ -58,16 +58,16 @@ const _clefSingleton = new clef.TrebleClef();
 export class RenderStack {
     streams: stream.Stream[] = [];
     voices: VFVoice[] = [];  // for the music
-    textVoices: VFVoice[] = [];  // for lyrics
+    // textVoices: VFVoice[] = [];  // for lyrics
     voiceToStreamMapping: Map<VFVoice, stream.Stream> = new Map();
 
     /**
-     * returns this.voices and this.textVoices as one array
+     * returns this.voices as a new array
      */
     allTickables(): VFVoice[] {
         const t: VFVoice[] = [];
         t.push(...this.voices);
-        t.push(...this.textVoices);
+        // t.push(...this.textVoices);
         return t;
     }
 
@@ -352,9 +352,9 @@ export class Renderer {
         stack.streams.push(s);
         stack.voiceToStreamMapping.set(vf_voice, s);
 
-        if (s.hasLyrics()) {
-            stack.textVoices.push(...this.getLyricVoices(s, stave));
-        }
+        // if (s.hasLyrics()) {
+        //     stack.textVoices.push(...this.getLyricVoices(s, stave));
+        // }
         return stave;
     }
 
@@ -382,7 +382,7 @@ export class Renderer {
     }
 
     /**
-     * Draws the Voices (music and text) from `this.stacks`
+     * Draws the Voices (just music no longer text) from `this.stacks`
      *
      */
     drawMeasureStacks(): void {
@@ -538,20 +538,20 @@ export class Renderer {
      *
      * s -- usually a Measure or Voice
      */
-    getLyricVoices(s: stream.Stream, stave: VFStave): VFVoice[] {
-        const textVoices = [];
-        const max_lyric_depth = Math.max(...s.notesAndRests.map(
-            (gn => gn.lyrics.length)
-        ));
-        for (let depth = 0; depth < max_lyric_depth + 1; depth++) {
-            const textVoice = this.vexflowVoice(s);
-            const lyrics: VFTextNote[] = this.vexflowLyrics(s, stave, depth);
-            textVoice.setStave(stave);
-            textVoice.addTickables(lyrics);
-            textVoices.push(textVoice);
-        }
-        return textVoices;
-    }
+    // getLyricVoices(s: stream.Stream, stave: VFStave): VFVoice[] {
+    //     const textVoices = [];
+    //     const max_lyric_depth = Math.max(...s.notesAndRests.map(
+    //         (gn => gn.lyrics.length)
+    //     ));
+    //     for (let depth = 0; depth < max_lyric_depth + 1; depth++) {
+    //         const textVoice = this.vexflowVoice(s);
+    //         const lyrics: VFTextNote[] = this.vexflowLyrics(s, stave, depth);
+    //         textVoice.setStave(stave);
+    //         textVoice.addTickables(lyrics);
+    //         textVoices.push(textVoice);
+    //     }
+    //     return textVoices;
+    // }
 
     /**
      * Aligns all of `this.stacks` (after they've been prepared) so they align properly.
@@ -953,56 +953,56 @@ export class Renderer {
         return notes;
     }
 
-    /**
-     * Gets an Array of `Vex.Flow.TextNote` objects from any lyrics found in s at a given lyric depth.
-     */
-    vexflowLyrics(s: stream.Stream, stave?: VFStave, depth: number=0): VFTextNote[] {
-        // runs on a flat, gapless, no-overlap stream, returns a list of TextNote objects...
-        const lyricTextNotes: VFTextNote[] = [];
-        for (const el of s.notesAndRests) {
-            const lyricsArray = el.lyrics;
-            if (lyricsArray === undefined) {
-                continue;
-            }
-            let text: string = '';
-            let d = el.duration;
-
-            // connectors deal with hyphens.
-            let addConnector: boolean|string = false;
-            const font = {
-                family: 'Serif',
-                size: 12,
-                weight: '',
-            };
-
-            const lyricAtDepth = lyricsArray[depth];  // rename lyricAtDepth
-            if (lyricAtDepth) {
-                text = lyricAtDepth.text ?? '';
-                if (['middle', 'begin'].includes(lyricAtDepth.syllabic)) {
-                    addConnector = ' ' + lyricAtDepth.lyricConnector;
-                    const tempQl = el.duration.quarterLength / 2.0;
-                    d = new duration.Duration(tempQl);
-                }
-                if (lyricAtDepth.style.fontFamily) {
-                    font.family = lyricAtDepth.style.fontFamily;
-                }
-                if (lyricAtDepth.style.fontSize) {
-                    font.size = lyricAtDepth.style.fontSize;
-                }
-                if (lyricAtDepth.style.fontWeight) {
-                    font.weight = lyricAtDepth.style.fontWeight;
-                }
-            }
-            const line = 11 + (depth * 2);
-            const t1 = getTextNote(text, font, d, stave, lyricAtDepth, line);
-            lyricTextNotes.push(t1);
-            if (addConnector !== false) {
-                const connector = getTextNote(addConnector, font, d, stave, undefined, line);
-                lyricTextNotes.push(connector);
-            }
-        }
-        return lyricTextNotes;
-    }
+    // /**
+    //  * Gets an Array of `Vex.Flow.TextNote` objects from any lyrics found in s at a given lyric depth.
+    //  */
+    // vexflowLyrics(s: stream.Stream, stave?: VFStave, depth: number=0): VFTextNote[] {
+    //     // runs on a flat, gapless, no-overlap stream, returns a list of TextNote objects...
+    //     const lyricTextNotes: VFTextNote[] = [];
+    //     for (const el of s.notesAndRests) {
+    //         const lyricsArray = el.lyrics;
+    //         if (lyricsArray === undefined) {
+    //             continue;
+    //         }
+    //         let text: string = '';
+    //         let d = el.duration;
+    //
+    //         // connectors deal with hyphens.
+    //         let addConnector: boolean|string = false;
+    //         const font = {
+    //             family: 'Serif',
+    //             size: 12,
+    //             weight: '',
+    //         };
+    //
+    //         const lyricAtDepth = lyricsArray[depth];  // rename lyricAtDepth
+    //         if (lyricAtDepth) {
+    //             text = lyricAtDepth.text ?? '';
+    //             if (['middle', 'begin'].includes(lyricAtDepth.syllabic)) {
+    //                 addConnector = ' ' + lyricAtDepth.lyricConnector;
+    //                 const tempQl = el.duration.quarterLength / 2.0;
+    //                 d = new duration.Duration(tempQl);
+    //             }
+    //             if (lyricAtDepth.style.fontFamily) {
+    //                 font.family = lyricAtDepth.style.fontFamily;
+    //             }
+    //             if (lyricAtDepth.style.fontSize) {
+    //                 font.size = lyricAtDepth.style.fontSize;
+    //             }
+    //             if (lyricAtDepth.style.fontWeight) {
+    //                 font.weight = lyricAtDepth.style.fontWeight;
+    //             }
+    //         }
+    //         const line = 11 + (depth * 2);
+    //         const t1 = getTextNote(text, font, d, stave, lyricAtDepth, line);
+    //         lyricTextNotes.push(t1);
+    //         if (addConnector !== false) {
+    //             const connector = getTextNote(addConnector, font, d, stave, undefined, line);
+    //             lyricTextNotes.push(connector);
+    //         }
+    //     }
+    //     return lyricTextNotes;
+    // }
 
     /**
      * Creates a Vex.Flow.Voice of the appropriate length given a Stream.
@@ -1248,32 +1248,32 @@ export class Renderer {
     }
 }
 
-export function getTextNote(
-    text: string,
-    font: VFFontInfo,
-    d: duration.Duration,
-    stave: VFStave,
-    lyricObj: note.Lyric = undefined,
-    line: number = 11,
-): VFTextNote {
-    // console.log(text, font, d);
-    // noinspection TypeScriptValidateJSTypes
-    const t1 = new VFTextNote({
-        text,
-        font,
-        duration: d.vexflowDuration,
-    })
-        .setLine(line)
-        .setStave(stave)
-        .setJustification(VFTextNote.Justification.LEFT);
-    if (lyricObj) {
-        t1.setStyle(lyricObj.style);
-    }
-    if (d.tuplets.length > 0) {
-        t1.applyTickMultiplier(d.tuplets[0].numberNotesNormal, d.tuplets[0].numberNotesActual);
-    }
-    return t1;
-}
+// export function getTextNote(
+//     text: string,
+//     font: VFFontInfo,
+//     d: duration.Duration,
+//     stave: VFStave,
+//     lyricObj: note.Lyric = undefined,
+//     line: number = 11,
+// ): VFTextNote {
+//     // console.log(text, font, d);
+//     // noinspection TypeScriptValidateJSTypes
+//     const t1 = new VFTextNote({
+//         text,
+//         font,
+//         duration: d.vexflowDuration,
+//     })
+//         .setLine(line)
+//         .setStave(stave)
+//         .setJustification(VFTextNote.Justification.LEFT);
+//     if (lyricObj) {
+//         t1.setStyle(lyricObj.style);
+//     }
+//     if (d.tuplets.length > 0) {
+//         t1.applyTickMultiplier(d.tuplets[0].numberNotesNormal, d.tuplets[0].numberNotesActual);
+//     }
+//     return t1;
+// }
 
 
 

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -1083,7 +1083,7 @@ export class Renderer {
      * If a stream has parts (NOT CHECKED HERE) create and
      * draw an appropriate Vex.Flow.StaveConnector
      */
-    addStaffConnectors(s?: stream.Score) {
+    addStaffConnectors(s?: stream.Score): void {
         if (s === undefined) {
             s = (this.stream as stream.Score);
         }

--- a/testHTML/m21jSandbox.html
+++ b/testHTML/m21jSandbox.html
@@ -16,8 +16,8 @@
             border: 10px solid #afa;
             font-family: "Courier", monospace;
             font-size: 14px;
-            width: 1000px;
-            height: 200px;
+            width: 90%;
+            height: 300px;
         }
         div.editor-error .text {
             background: #faa;
@@ -47,10 +47,14 @@
         <p></p>
         <div class="example sandbox">
             <textarea id="sandbox" class="editor">
-const s = new music21.stream.Stream();
-const n = new music21.note.Note("C#");
+const s = new music21.stream.Measure();
+const n = new music21.note.Note("C#4");
+n.addLyric('lulli-');
+n.addLyric('sad');
 n.duration.type = "half";
-const n2 = new music21.note.Note("C#");
+const n2 = new music21.note.Note("A3");
+n2.addLyric('bye');
+n2.addLyric('day');
 n2.duration.type = "quarter";
 const n3 = new music21.note.Note("C#");
 n3.duration.type = "quarter";
@@ -58,11 +62,12 @@ s.append(new music21.meter.TimeSignature('4/4'));
 s.append(n);
 s.append(n2);
 s.append(n3);
-s.replaceDOM();
+s.renderOptions.marginBottom = 80;
+s.replaceDOM('#mainSVG');
 </textarea>
             <p></p>
             <div class='streamHolding' id='mainSVG'>
-                <svg width="625" height="420"></svg>
+                <svg width="525" height="220"></svg>
             </div>
             <p></p>
         </div>

--- a/testHTML/m21jSandbox.html
+++ b/testHTML/m21jSandbox.html
@@ -62,7 +62,7 @@ s.replaceDOM();
 </textarea>
             <p></p>
             <div class='streamHolding' id='mainSVG'>
-                <svg width="625" height="360"></svg>
+                <svg width="625" height="420"></svg>
             </div>
             <p></p>
         </div>

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -1,5 +1,5 @@
 import * as QUnit from 'qunit';
-import {TextNote as VFTextNote} from 'vexflow';
+// import {TextNote as VFTextNote} from 'vexflow';
 
 import * as music21 from '../../src/main';
 import type { StreamIterator } from '../../src/stream/iterator';
@@ -243,21 +243,23 @@ export default function tests() {
         m.append(n);
         m.renderOptions.heightBelowStaff = 40;
         m.appendNewDOM();
-        const t1 = m.activeVFRenderer.stacks[0].textVoices[0].getTickables()[0] as VFTextNote;
-        assert.equal(
-            // Error: Property 'text' does not exist on type 'Tickable'.
-            // @ts-ignore
-            t1.text,
-            'first',
-            'first lyric is "first".'
-        );
-        const t2 = m.activeVFRenderer.stacks[0].textVoices[1].getTickables()[0] as VFTextNote;
-        assert.equal(
-            // Error: Property 'text' does not exist on type 'Tickable'.
-            // @ts-ignore
-            t2.text,
-            'second',
-            'second lyric is "second".'
-        );
+
+        assert.equal(n.lyrics.length, 2, 'note has two lyrics');
+        // const t1 = m.activeVFRenderer.stacks[0].textVoices[0].getTickables()[0] as VFTextNote;
+        // assert.equal(
+        //     // Error: Property 'text' does not exist on type 'Tickable'.
+        //     // @ts-ignore
+        //     t1.text,
+        //     'first',
+        //     'first lyric is "first".'
+        // );
+        // const t2 = m.activeVFRenderer.stacks[0].textVoices[1].getTickables()[0] as VFTextNote;
+        // assert.equal(
+        //     // Error: Property 'text' does not exist on type 'Tickable'.
+        //     // @ts-ignore
+        //     t2.text,
+        //     'second',
+        //     'second lyric is "second".'
+        // );
     });
 }


### PR DESCRIPTION
Lyrics have really not been working for a very long time since upgrading to Vexflow 3.  The whole system of TextNotes was not properly working with Formatter.

Replacing them with the suggested way of using Annotations.  But Annotations really, REALLY, REAALLY want to stick to the note's vertical position.  So there are a number of shims now (vfShims returns!) to make them work properly.

Still to-do:  trying to place hyphens halfway between notes.  But this is much better than the current process where they were placed on top of other notes!
