### PR TITLE
Fix stem directions for unbeamed notes

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1523,11 +1523,13 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
 
     /**
      * makeNotation does not do anything yet, but it is a placeholder
-     * so it can start to be called.
+     * so it can start to be called.  NOTE: Currently assumes that
+     * it is being called on FLAT Stream!
      *
-     * TODO: move call to makeBeams from renderVexflow to here.
+     * TODO: move call to makeBeams from renderVexflow to here once
+     *     it works on recursive streams.
      */
-    makeNotation({ inPlace=true, overrideStatus=false }={}): this {
+    makeNotation({ inPlace=false, overrideStatus=false }={}): this {
         let out: this;
         if (inPlace) {
             out = this;
@@ -1535,6 +1537,7 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
             out = this.clone(true);
         }
         // already made a copy
+        makeNotation.setStemDirectionForUnspecified(out);
         out.makeAccidentals({ inPlace: true, overrideStatus });
         return out;
     }

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -345,7 +345,7 @@ export class Renderer {
         optionalStave?: VFStave,
         optional_renderOp?: renderOptions.RenderOptions,
     ): VFStave {
-        s.makeNotation({ overrideStatus: true });
+        s.makeNotation({ inPlace: true, overrideStatus: true });
         const stave: VFStave = optionalStave ?? this.renderStave(s, optional_renderOp);
         s.activeVFStave = stave;
         const vf_voice = this.getVoice(s, stave);

--- a/tests/moduleTests/pitch.ts
+++ b/tests/moduleTests/pitch.ts
@@ -280,7 +280,7 @@ export default function tests() {
             "4/4 fn1 fn1 e-8 e'-8 fn4 en4 e'n4"
         ).flatten();
         // Function does not work, stream.ts 1353
-        //convertedNotes.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False);
+        // convertedNotes.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False);
         const els = convertedNotes.elements as music21.note.Note[];
         assert.equal(els[2].pitch.accidental.name, 'natural', 'Natural');
         //assert.equal(els[2].pitch.accidental.displayStatus, 'True');


### PR DESCRIPTION
Stem directions for unbeamed notes were not being calculated.  Was falling back on Vexflow determination, but Vexflow was totally wrong for chords.