### PR TITLE
Augmented Second Chord Stems

### DIFF
--- a/src/stream/makeNotation.ts
+++ b/src/stream/makeNotation.ts
@@ -183,6 +183,18 @@ export function setStemDirectionForUnspecified(
     }
 
     for (const n of s.rc(note.NotRest)) {
+        if (n.pitches.length > 1) {
+            const pitchSet = new Set(n.pitches.map(p => p.diatonicNoteNum));
+            if (pitchSet.size < n.pitches.length) {
+                // bug in Vexflow v4 at least -- chords with augmented seconds
+                // and down stems do no render properly.
+                // set their stems to 'unspecified' which Vexflow will currently
+                // render as upstems.
+                n.stemDirection = 'unspecified';
+                continue;
+            }
+        }
+
         if (n.stemDirection !== 'unspecified') {
             continue;
         }
@@ -202,6 +214,9 @@ export function setStemDirectionForUnspecified(
 const _up_down: readonly string[] = ['up', 'down'];
 const _up_down_unspecified: readonly string[] = ['up', 'down', 'unspecified'];
 
+/**
+ *  Set stem directions for all notes in a beam group.
+ */
 export function setStemDirectionOneGroup(
     group: note.NotRest[],
     {


### PR DESCRIPTION
Temporarily work around a Vexflow bug where chords with augmented seconds and stems down do not draw properly.


Before
<img width="172" alt="Screenshot 2024-06-21 at 14 42 30" src="https://github.com/cuthbertLab/music21j/assets/3521479/ff7598e8-0f04-462c-9913-5bb175b3c04e">

After
<img width="159" alt="Screenshot 2024-06-21 at 14 43 56" src="https://github.com/cuthbertLab/music21j/assets/3521479/2b58219f-9b83-4772-aeec-1246d75336f6">
