### PR TITLE
Fix beatGroups in 5/4, 6/4, 7/4, 9/4, 12/4

### DIFF
--- a/src/meter.ts
+++ b/src/meter.ts
@@ -186,14 +186,7 @@ export class TimeSignature extends base.Music21Object {
     computeBeatGroups(): number[][] {
         const tempBeatGroups = [];
         let numBeats = this.numerator;
-        let beatValue = this.denominator;
-        if (beatValue < 8 && numBeats >= 5) {
-            const beatsToEighthNoteRatio = 8 / beatValue;
-            // hopefully beatValue is an int -- right Brian Ferneyhough?
-            beatValue = 8;
-            numBeats *= beatsToEighthNoteRatio;
-        }
-
+        const beatValue = this.denominator;
         if (beatValue >= 8) {
             if ([4, 2].includes(numBeats)) {  // 4/8 and 2/8 should have eighth beats
                 tempBeatGroups.push([1, beatValue]);

--- a/tests/moduleTests/meter.ts
+++ b/tests/moduleTests/meter.ts
@@ -250,17 +250,28 @@ export default function tests() {
                 `${meterString} should have beat groups: ${expectedBeatGroups}`,
             );
         }
-        assertBeatGroups('2/8', [[1, 8]]);
-        assertBeatGroups('3/8', [[3, 8]]);
-        assertBeatGroups('4/8', [[1, 8]]);
-        assertBeatGroups('6/8', [[3, 8], [3, 8]]);
-        assertBeatGroups('9/8', [[3, 8], [3, 8], [3, 8]]);
-        assertBeatGroups('12/8', [[3, 8], [3, 8], [3, 8], [3, 8]]);
+        assertBeatGroups('2/2', [[1, 2]]);
+        assertBeatGroups('3/2', [[1, 2]]);
+        assertBeatGroups('4/2', [[1, 2]]);
         assertBeatGroups('2/4', [[2, 8]]);
         assertBeatGroups('3/4', [[2, 8]]);
         assertBeatGroups('4/4', [[2, 8]]);
+        assertBeatGroups('5/4', [[2, 8]]);
         assertBeatGroups('6/4', [[2, 8]]);
         assertBeatGroups('9/4', [[2, 8]]);
         assertBeatGroups('12/4', [[2, 8]]);
+        assertBeatGroups('2/8', [[1, 8]]);
+        assertBeatGroups('3/8', [[3, 8]]);
+        assertBeatGroups('4/8', [[1, 8]]);
+        assertBeatGroups('5/8', [[3, 8], [2, 8]]);
+        assertBeatGroups('6/8', [[3, 8], [3, 8]]);
+        assertBeatGroups('9/8', [[3, 8], [3, 8], [3, 8]]);
+        assertBeatGroups('12/8', [[3, 8], [3, 8], [3, 8], [3, 8]]);
+        assertBeatGroups('3/16', [[3, 16]]);
+        assertBeatGroups('4/16', [[1, 16]]);
+        assertBeatGroups('5/16', [[3, 16], [2, 16]]);
+        assertBeatGroups('6/16', [[3, 16], [3, 16]]);
+        assertBeatGroups('9/16', [[3, 16], [3, 16], [3, 16]]);
+        assertBeatGroups('12/16', [[3, 16], [3, 16], [3, 16], [3, 16]]);
     });
 }

--- a/tests/moduleTests/meter.ts
+++ b/tests/moduleTests/meter.ts
@@ -240,4 +240,27 @@ export default function tests() {
         );
         assert.equal(m.beatDuration.dots, 1, 'beatDuration has dot');
     });
+
+    test('music21.meter.TimeSignature.beatGroups', assert => {
+        function assertBeatGroups(meterString: string, expectedBeatGroups: number[][]) {
+            const m = new music21.meter.TimeSignature(meterString);
+            assert.deepEqual(
+                m.beatGroups,
+                expectedBeatGroups,
+                `${meterString} should have beat groups: ${expectedBeatGroups}`,
+            );
+        }
+        assertBeatGroups('2/8', [[1, 8]]);
+        assertBeatGroups('3/8', [[3, 8]]);
+        assertBeatGroups('4/8', [[1, 8]]);
+        assertBeatGroups('6/8', [[3, 8], [3, 8]]);
+        assertBeatGroups('9/8', [[3, 8], [3, 8], [3, 8]]);
+        assertBeatGroups('12/8', [[3, 8], [3, 8], [3, 8], [3, 8]]);
+        assertBeatGroups('2/4', [[2, 8]]);
+        assertBeatGroups('3/4', [[2, 8]]);
+        assertBeatGroups('4/4', [[2, 8]]);
+        assertBeatGroups('6/4', [[2, 8]]);
+        assertBeatGroups('9/4', [[2, 8]]);
+        assertBeatGroups('12/4', [[2, 8]]);
+    });
 }

--- a/tests/moduleTests/meter.ts
+++ b/tests/moduleTests/meter.ts
@@ -258,6 +258,7 @@ export default function tests() {
         assertBeatGroups('4/4', [[2, 8]]);
         assertBeatGroups('5/4', [[2, 8]]);
         assertBeatGroups('6/4', [[2, 8]]);
+        assertBeatGroups('7/4', [[2, 8]]);
         assertBeatGroups('9/4', [[2, 8]]);
         assertBeatGroups('12/4', [[2, 8]]);
         assertBeatGroups('2/8', [[1, 8]]);
@@ -265,12 +266,14 @@ export default function tests() {
         assertBeatGroups('4/8', [[1, 8]]);
         assertBeatGroups('5/8', [[3, 8], [2, 8]]);
         assertBeatGroups('6/8', [[3, 8], [3, 8]]);
+        assertBeatGroups('7/8', [[3, 8], [2, 8], [2, 8]]);
         assertBeatGroups('9/8', [[3, 8], [3, 8], [3, 8]]);
         assertBeatGroups('12/8', [[3, 8], [3, 8], [3, 8], [3, 8]]);
         assertBeatGroups('3/16', [[3, 16]]);
         assertBeatGroups('4/16', [[1, 16]]);
         assertBeatGroups('5/16', [[3, 16], [2, 16]]);
         assertBeatGroups('6/16', [[3, 16], [3, 16]]);
+        assertBeatGroups('7/16', [[3, 16], [2, 16], [2, 16]]);
         assertBeatGroups('9/16', [[3, 16], [3, 16], [3, 16]]);
         assertBeatGroups('12/16', [[3, 16], [3, 16], [3, 16], [3, 16]]);
     });


### PR DESCRIPTION
This PR removes a code block that was causing 5/4, 6/4, 7/4, 9/4, and 12/4 to create triple beat subdivisions:

__Previous__:

```typescript
const ts = new music21.meter.TimeSignature('6/4');
console.log(ts.computeBeatGroups());
>>> [[3, 8], [3, 8], [3, 8], [3, 8]]
```

__Current__:

```typescript
const ts = new music21.meter.TimeSignature('6/4');
console.log(ts.computeBeatGroups());
>>> [[2, 8]]
```