### PR TITLE
Improve loader docs and articulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Music21j
-=========
+# Music21j
 
 **Music21j: An Interactive Framework for Musical Analysis**
 
@@ -26,8 +25,7 @@ targets browsers no more than 30 months old.
 Safari is the only major desktop browser for which there is no out of the box 
 support for MIDI devices.
 
-Documentation
--------------
+## Documentation
 This README appears in both the GitHub home page and the documentation
 home page; to make the following links work, go to the documentation
 page at http://web.mit.edu/music21/music21j/doc/ .
@@ -39,14 +37,12 @@ or a Class such as {@link music21.note.Note} or {@link music21.stream.Stream}.
 
 (Ignore "Modules" they're not useful and duplicate the namespace pages).
 
-Example
---------
+## Example
 Install by downloading a copy of the music21 code to your own webserver.
 
 ```sh
 % npm install music21j
 ```
-
 
 If this line (`npm install`) doesn't work, download the
 latest version of `node.js` from https://nodejs.org/en/download/
@@ -98,19 +94,49 @@ const n = new music21.note.Note('F#');
 // etc.
 ```
 
-Version
---------
+### Embedding, etc.
+Music21j was originally intended for self-hosting, so embedding is not
+yet as simple as it should be.
+
+To load soundfonts from other locations (like in a CDN), 
+(1) set a global `m21conf` variable to disable loading soundfonts,
+(2) load the music21j script, and (3) set the new soundfont location,
+and (4) load the soundfont.
+
+This fragment shows how to do it.  A working implementation is in the
+testHTML directory as `sfElsewhereCDN.html`.
+
+```html
+<body>
+<script>
+    window.m21conf = { loadSoundfont: false };
+</script>
+<script 
+    src="https://cdn.jsdelivr.net/npm/music21j/releases/music21.debug.min.js"
+></script>
+<script>
+    music21.common.urls.soundfontUrl = 'https://raw.githubusercontent.com/gleitz/midi-js-soundfonts/gh-pages/FluidR3_GM/';
+    music21.miditools.loadSoundfont('clarinet', i => {
+       const tn = music21.tinyNotation.TinyNotation('4/4 c4 d e f g1');
+       tn.instrument = i;
+       tn.playStream();
+    });
+</script>
+</body>
+```
+
+
+
+## Version
 0.16 beta
 
 
-License
---------
+## License
 Music21j is released under the BSD 3-Clause License. Essentially you
 can do with it what you want so long as you leave in my copyright statements
 and do not represent that I endorse your product.
 
-Thanks
------------
+## Thanks
 
 Thanks to the following packages (among others) for making music21j possible:
 
@@ -135,8 +161,7 @@ and supported by the Music and Theater Arts section of [MIT].
 [jsdoc]:http://usejsdoc.org
 
 
-Dev Notes
-----------------
+## Dev Notes
 Build and watch with
 
 ```sh
@@ -166,8 +191,7 @@ for running tests one time without watch, you can use:
 $ grunt test_no_watch
 ```
 
-Publishing a new version
--------------------------
+### Publishing a new version
 You'll need to be part of the npm dev team.
 
 Two steps.  First make sure you have run:
@@ -214,6 +238,4 @@ $ npm install
 ```
 
 
-These docs will be changing in preparation for v. 1.0 release.
-
-
+These docs may change someday in preparation for v.1.0 release.

--- a/src/articulations.ts
+++ b/src/articulations.ts
@@ -77,14 +77,18 @@ export class Articulation extends prebase.ProtoM21Object {
 
     name: string;
     placement: ArticulationPlacement = ArticulationPlacement.NOTE_SIDE;
-    vexflowModifier: string;
+    vexflowModifier: string = '';
     dynamicScale: number = 1.0;
     lengthScale: number = 1.0;
 
     /**
-     * Generates a Vex.Flow.Articulation for this articulation.
+     * Generates a Vex.Flow.Articulation for this articulation if it is something
+     * vexflow can display.
      */
-    vexflow({stemDirection}: VexflowArticulationParams = {}): VFArticulation {
+    vexflow({stemDirection}: VexflowArticulationParams = {}): VFArticulation|null {
+        if (!this.vexflowModifier) {
+            return null;
+        }
         const vfa = new VFArticulation(this.vexflowModifier);
         setPlacementOnVexFlowArticulation(vfa, this.placement, stemDirection);
         return vfa;
@@ -97,10 +101,7 @@ export class Articulation extends prebase.ProtoM21Object {
 export class LengthArticulation extends Articulation {
     static get className() { return 'music21.articulation.LengthArticulation'; }
 
-    constructor() {
-        super();
-        this.name = 'length-articulation';
-    }
+    override name = 'length-articulation';
 }
 
 /**
@@ -109,10 +110,7 @@ export class LengthArticulation extends Articulation {
 export class DynamicArticulation extends Articulation {
     static get className() { return 'music21.articulation.DynamicArticulation'; }
 
-    constructor() {
-        super();
-        this.name = 'dynamic-articulation';
-    }
+    override name ='dynamic-articulation';
 }
 
 /**
@@ -121,10 +119,7 @@ export class DynamicArticulation extends Articulation {
 export class PitchArticulation extends Articulation {
     static get className() { return 'music21.articulation.PitchArticulation'; }
 
-    constructor() {
-        super();
-        this.name = 'pitch-articulation';
-    }
+    override name = 'pitch-articulation';
 }
 
 /**
@@ -133,10 +128,7 @@ export class PitchArticulation extends Articulation {
 export class TimbreArticulation extends Articulation {
     static get className() { return 'music21.articulation.TimbreArticulation'; }
 
-    constructor() {
-        super();
-        this.name = 'timbre-articulation';
-    }
+    override name = 'timbre-articulation';
 }
 
 /**
@@ -145,12 +137,9 @@ export class TimbreArticulation extends Articulation {
 export class Accent extends DynamicArticulation {
     static get className() { return 'music21.articulation.Accent'; }
 
-    constructor() {
-        super();
-        this.name = 'accent';
-        this.vexflowModifier = 'a>';
-        this.dynamicScale = 1.5;
-    }
+    override name = 'accent';
+    override vexflowModifier = 'a>';
+    override dynamicScale = 1.5;
 }
 
 /**
@@ -159,51 +148,35 @@ export class Accent extends DynamicArticulation {
 export class StrongAccent extends Accent {
     static get className() { return 'music21.articulation.StrongAccent'; }
 
-    constructor() {
-        super();
-        this.name = 'strong accent';
-        this.vexflowModifier = 'a^';
-        this.dynamicScale = 2.0;
-    }
+    override name = 'strong accent';
+    override vexflowModifier = 'a^';
+    override dynamicScale = 2.0;
 }
 
-/**
- * no playback for now.
- */
 export class Staccato extends LengthArticulation {
     static get className() { return 'music21.articulation.Staccato'; }
 
-    constructor() {
-        super();
-        this.name = 'staccato';
-        this.vexflowModifier = 'a.';
-    }
+    override name = 'staccato';
+    override vexflowModifier = 'a.';
+    override lengthScale = 0.6;
 }
 
-/**
- * no playback for now.
- */
 export class Staccatissimo extends Staccato {
     static get className() { return 'music21.articulation.Staccatissimo'; }
 
-    constructor() {
-        super();
-        this.name = 'staccatissimo';
-        this.vexflowModifier = 'av';
-    }
+    override name = 'staccatissimo';
+    override vexflowModifier = 'av';
+    override lengthScale = 0.3;
 }
 
 /**
- * no playback or display for now.
+ * no difference in playback from staccato.  no display.
  */
 export class Spiccato extends Staccato {
     static get className() { return 'music21.articulation.Spiccato'; }
 
-    constructor() {
-        super();
-        this.name = 'spiccato';
-        this.vexflowModifier = undefined;
-    }
+    override name = 'spiccato';
+    override vexflowModifier = '';
 }
 
 /**
@@ -225,9 +198,6 @@ export class Marcato extends DynamicArticulation {
 export class Tenuto extends LengthArticulation {
     static get className() { return 'music21.articulation.Tenuto'; }
 
-    constructor() {
-        super();
-        this.name = 'tenuto';
-        this.vexflowModifier = 'a-';
-    }
+    override name = 'tenuto';
+    override vexflowModifier = 'a-';
 }

--- a/src/expressions.ts
+++ b/src/expressions.ts
@@ -30,7 +30,10 @@ export class Expression extends base.Music21Object {
      *
      * (this is not right for all cases)
      */
-    vexflow({stemDirection}: VexflowArticulationParams = {}): VFArticulation | VFOrnament {
+    vexflow({stemDirection}: VexflowArticulationParams = {}): VFArticulation | VFOrnament | null {
+        if (!this.vexflowModifier) {
+            return null;
+        }
         const vfe = new VFArticulation(this.vexflowModifier);
         setPlacementOnVexFlowArticulation(vfe, this.placement, stemDirection);
         return vfe;
@@ -56,7 +59,10 @@ export class Ornament extends Expression {
     static get className() { return 'music21.expressions.Ornament'; }
 
     name: string = 'ornament';
-    vexflow({stemDirection}: VexflowArticulationParams = {}): VFOrnament {
+    vexflow({stemDirection}: VexflowArticulationParams = {}): VFOrnament | null {
+        if (!this.vexflowModifier) {
+            return null;
+        }
         const vfe = new VFOrnament(this.vexflowModifier);
         setPlacementOnVexFlowArticulation(vfe, this.placement, stemDirection);
         return vfe;

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -180,48 +180,35 @@ export const info: InstrumentFileInfo[] = [
 /**
  * Represents an instrument.  instrumentNames are found in the ext/soundfonts directory
  *
+ * Note that unlike music21p -- for now there is only one instrument object: Instrument
+ * there are no Piano, Flute, etc. objects
+ *
  * See music21.miditools and esp. `loadSoundfont` for a way of loading soundfonts into
  * instruments.
- *
- * @param {string} instrumentName
- * @property {string|undefined} partId
- * @property {string|undefined} partName
- * @property {string|undefined} partAbbreviation
- * @property {string|undefined} instrumentId
- * @property {string|undefined} instrumentName
- * @property {string|undefined} instrumentAbbreviation
- * @property {int|undefined} midiProgram
- * @property {int|undefined} midiChannel
- * @property {int|undefined} lowestNote
- * @property {int|undefined} highestNote
- * @property {Boolean} inGMPercMap=false
- * @property {string|undefined} soundfontFn
- * @property {string|undefined} oggSoundfont - url of oggSoundfont for this instrument
- * @property {string|undefined} mp3Soundfont - url of mp3Soundfont for this instrument
  */
 export class Instrument extends base.Music21Object {
     static get className() { return 'music21.instrument.Instrument'; }
 
-    partId = undefined;
-    partName = undefined;
-    partAbbreviation = undefined;
+    partId: string = undefined;
+    partName: string = undefined;
+    partAbbreviation: string = undefined;
 
-    instrumentId = undefined;
-    instrumentName = '';
-    instrumentAbbreviation = undefined;
-    midiProgram = undefined;
-    _midiChannel = undefined;
+    instrumentId: string = undefined;
+    instrumentName: string = '';
+    instrumentAbbreviation: string = undefined;
+    midiProgram: number|undefined = undefined;
+    _midiChannel: number|undefined = undefined;
 
-    lowestNote = undefined;
-    highestNote = undefined;
+    lowestNote: number = undefined;
+    highestNote: number = undefined;
 
     transposition: interval.Interval;
 
-    inGMPercMap = false;
-    soundfontFn = undefined;
+    inGMPercMap: boolean = false;
+    soundfontFn: string = undefined;
 
 
-    constructor(instrumentName='') {
+    constructor(instrumentName: string = '') {
         super();
         this.classSortOrder = -25;
         this.instrumentName = instrumentName;
@@ -263,22 +250,22 @@ export class Instrument extends base.Music21Object {
         return undefined;
     }
 
-    get oggSoundfont() {
+    get oggSoundfont(): string {
         return this.soundfontFn + '-ogg.js';
     }
 
-    get mp3Soundfont() {
+    get mp3Soundfont(): string {
         return this.soundfontFn + '-mp3.js';
     }
 
-    get midiChannel() {
+    get midiChannel(): number {
         if (this._midiChannel === undefined) {
             this.autoAssignMidiChannel();
         }
         return this._midiChannel;
     }
 
-    set midiChannel(ch) {
+    set midiChannel(ch: number) {
         this._midiChannel = ch;
     }
 }
@@ -290,7 +277,7 @@ export class Instrument extends base.Music21Object {
  * fn - name or filename of instrument
  * [inst] - instrument object to load into
  */
-export function find(fn: string, inst?: Instrument): Instrument {
+export function find(fn: string, inst?: Instrument): Instrument|undefined {
     if (inst === undefined) {
         inst = new Instrument();
     }

--- a/src/note.ts
+++ b/src/note.ts
@@ -587,10 +587,16 @@ export class NotRest extends GeneralNote {
             }
         }
         for (const art of this.articulations) {
-            vfn.addModifier(art.vexflow({stemDirection: useStemDirection}));
+            const vf_art = art.vexflow({stemDirection: useStemDirection});
+            if (vf_art) {
+                vfn.addModifier(vf_art);
+            }
         }
         for (const exp of this.expressions) {
-            vfn.addModifier(exp.vexflow({stemDirection: useStemDirection}));
+            const vf_exp = exp.vexflow({stemDirection: useStemDirection});
+            if (vf_exp) {
+                vfn.addModifier(vf_exp);
+            }
         }
         if (this.noteheadColor !== undefined) {
             vfn.setStyle({ fillStyle: this.noteheadColor, strokeStyle: this.noteheadColor });
@@ -783,6 +789,10 @@ export class Note extends NotRest {
         // Note, not rest
         const midNum = this.pitch.midi;
         let stopTime = milliseconds / 1000;
+        for (const art of this.articulations) {
+            stopTime *= art.lengthScale;
+        }
+
         if (nextElement instanceof Note) {
             if (nextElement.pitch.midi !== this.pitch.midi && playLegato) {
                 stopTime += 60 * 0.25 / tempo; // legato -- play 16th note longer

--- a/src/parseLoader.ts
+++ b/src/parseLoader.ts
@@ -8,15 +8,14 @@ import * as miditools from './miditools';
 import * as tinyNotation from './tinyNotation';
 
 export function runConfiguration() {
-    let conf;
+    let conf: Record<string, any> = {};
     // noinspection JSUnresolvedVariable
     if (typeof (<any> window).m21conf !== 'undefined') {
         // noinspection JSUnresolvedVariable
-        conf = (<any> window).m21conf;
+        conf = (<any> window).m21conf as Record<string, any>;
     } else {
         conf = loadConfiguration();
     }
-    conf.warnBanner = (conf.warnBanner !== undefined) ? conf.warnBanner : warnBanner();
     conf.loadSoundfont = (
         conf.loadSoundfont !== undefined
             ? conf.loadSoundfont
@@ -76,7 +75,7 @@ export function loadDefaultSoundfont(conf) {
     if (!conf.loadSoundfont || (['no', 'false'].includes(conf.loadSoundfont))) {
         return undefined;
     }
-    let instrument;
+    let instrument: string;
     if (conf.loadSoundfont === true) {
         instrument = 'acoustic_grand_piano';
     } else {
@@ -86,21 +85,20 @@ export function loadDefaultSoundfont(conf) {
 }
 
 /**
- *
- * @returns {{}}
+ * Find the configuration as a JSON-encoded m21conf attribute on the script tag.
  */
-export function loadConfiguration() {
+export function loadConfiguration(): Record<string, any> {
     const rawConf = getM21attribute('m21conf');
     if (!rawConf) {
-        return {};
+        return {} as Record<string, any>;
     }
 
-    let m21conf;
+    let m21conf: Record<string, any>;
     try {
-        m21conf = JSON.parse(rawConf);
+        m21conf = JSON.parse(rawConf) as Record<string, any>;
     } catch (e) {
         console.warn('Unable to JSON parse music21 configuration' + rawConf.toString() + ' into m21conf');
-        m21conf = {};
+        m21conf = {} as Record<string, any>;
     }
     return m21conf;
 }
@@ -110,7 +108,7 @@ export function loadConfiguration() {
  * @param {string} [attribute=m21conf]
  * @returns {undefined|*|string}
  */
-export function getM21attribute(attribute='m21conf') {
+export function getM21attribute(attribute: string = 'm21conf'): string {
     // this is case insensitive.
     const scripts = document.getElementsByTagName('script');
     for (const s of Array.from(scripts)) {
@@ -123,12 +121,4 @@ export function getM21attribute(attribute='m21conf') {
         }
     }
     return undefined;
-}
-
-/**
- *
- * @returns {boolean}
- */
-export function warnBanner() {
-    return getM21attribute('warnBanner') !== 'no';
 }

--- a/testHTML/sfElsewhereCDN.html
+++ b/testHTML/sfElsewhereCDN.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--suppress JSConstantReassignment -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Embed Soundfonts from elsewhere</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+</head>
+<body>
+<h1>Embed Soundfonts from elsewhere</h1>
+<p>This script (view source) shows how music21 can be embedded (like in a Fiddle) and
+    load soundfonts from elsewhere.
+</p>
+<button role="button" class="btn btn-primary" onclick="playStream()">Click me!</button>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js" integrity="sha384-BBtl+eGJRgqQAUMxJ7pMwbEyER4l1g+O15P+16Ep7Q9Q+zqX6gSbd85u4mG4QzX+" crossorigin="anonymous"></script>
+<script>
+    window.m21conf = { loadSoundfont: false };
+</script>
+<script
+    src="https://cdn.jsdelivr.net/npm/music21j/releases/music21.debug.min.js"
+></script>
+<script>
+    music21.common.urls.soundfontUrl = 'https://raw.githubusercontent.com/gleitz/midi-js-soundfonts/gh-pages/FluidR3_GM/';
+    function playStream() {
+        music21.miditools.loadSoundfont('clarinet', i => {
+           const tn = music21.tinyNotation.TinyNotation('4/4 c4 d e f8 f g1');
+           tn.rc(music21.note.Note).get(-3).articulations.push(new music21.articulations.Staccatissimo);
+           tn.instrument = i;
+           tn.playStream();
+        });
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #115

Give instructions on how to use music21j remotely without hosting yourself.

Also: Fix problems with articulations and expressions without Vexflow versions.  Make length expressions play back better.