### PR TITLE
Fix beatGroups in 6/4, 9/4, 12/4 (take 2)

### DIFF
--- a/src/meter.ts
+++ b/src/meter.ts
@@ -208,7 +208,14 @@ export class TimeSignature extends base.Music21Object {
             tempBeatGroups.push([1, 1]);
         } else {
             // 4/4, 2/4, 3/4, standard stuff
-            tempBeatGroups.push([2, 8]);
+            if (numBeats % 3 === 0 && numBeats > 3) {
+                while (numBeats) {
+                    tempBeatGroups.push([3, beatValue]);
+                    numBeats -= 3;
+                }
+            } else {
+                tempBeatGroups.push([2, 8]);
+            }
         }
         return tempBeatGroups;
     }

--- a/src/meter.ts
+++ b/src/meter.ts
@@ -185,33 +185,34 @@ export class TimeSignature extends base.Music21Object {
      */
     computeBeatGroups(): number[][] {
         const tempBeatGroups = [];
-        let numBeats = this.numerator;
-        const beatValue = this.denominator;
-        if (beatValue >= 8) {
-            if ([4, 2].includes(numBeats)) {  // 4/8 and 2/8 should have eighth beats
-                tempBeatGroups.push([1, beatValue]);
+        const meterNumerator = this.numerator;
+        const meterDenominator = this.denominator;
+        if (meterDenominator >= 8) {
+            if ([4, 2].includes(meterNumerator)) {  // 4/8 and 2/8 should have eighth beats
+                tempBeatGroups.push([1, meterDenominator]);
             } else {
-                while (numBeats >= 5) {
-                    tempBeatGroups.push([3, beatValue]);
-                    numBeats -= 3;
+                let remainingUnitsInMeter: number = meterNumerator;
+                while (remainingUnitsInMeter >= 5) {
+                    tempBeatGroups.push([3, meterDenominator]);
+                    remainingUnitsInMeter -= 3;
                 }
-                if (numBeats === 4) {
-                    tempBeatGroups.push([2, beatValue]);
-                    tempBeatGroups.push([2, beatValue]);
-                } else if (numBeats > 0) {
-                    tempBeatGroups.push([numBeats, beatValue]);
+                if (remainingUnitsInMeter === 4) {
+                    tempBeatGroups.push([2, meterDenominator]);
+                    tempBeatGroups.push([2, meterDenominator]);
+                } else if (remainingUnitsInMeter > 0) {
+                    tempBeatGroups.push([remainingUnitsInMeter, meterDenominator]);
                 }
             }
-        } else if (beatValue === 2) {
+        } else if (meterDenominator === 2) {
             tempBeatGroups.push([1, 2]);
-        } else if (beatValue <= 1) {
+        } else if (meterDenominator <= 1) {
             tempBeatGroups.push([1, 1]);
         } else {
             // 4/4, 2/4, 3/4, standard stuff
-            if (numBeats % 3 === 0 && numBeats > 3) {
-                while (numBeats) {
-                    tempBeatGroups.push([3, beatValue]);
-                    numBeats -= 3;
+            if (meterNumerator % 3 === 0 && meterNumerator > 3) {
+                const numBeats = meterNumerator / 3;
+                for (let i = 0; i < numBeats; i++) {
+                    tempBeatGroups.push([3, meterDenominator]);
                 }
             } else {
                 tempBeatGroups.push([2, 8]);

--- a/tests/moduleTests/meter.ts
+++ b/tests/moduleTests/meter.ts
@@ -257,10 +257,10 @@ export default function tests() {
         assertBeatGroups('3/4', [[2, 8]]);
         assertBeatGroups('4/4', [[2, 8]]);
         assertBeatGroups('5/4', [[2, 8]]);
-        assertBeatGroups('6/4', [[2, 8]]);
+        assertBeatGroups('6/4', [[3, 4], [3, 4]]);
         assertBeatGroups('7/4', [[2, 8]]);
-        assertBeatGroups('9/4', [[2, 8]]);
-        assertBeatGroups('12/4', [[2, 8]]);
+        assertBeatGroups('9/4', [[3, 4], [3, 4], [3, 4]]);
+        assertBeatGroups('12/4', [[3, 4], [3, 4], [3, 4], [3, 4]]);
         assertBeatGroups('2/8', [[1, 8]]);
         assertBeatGroups('3/8', [[3, 8]]);
         assertBeatGroups('4/8', [[1, 8]]);


### PR DESCRIPTION
Follows after https://github.com/cuthbertLab/music21j/pull/260: compound meters should have a compound beat grouping.

This PR also renames some variables, mostly just to help me follow the logic for compound meters: 
- numBeats -> meterNumerator
- beatValue -> meterDenominator
- Rewrote some code to not mutate meterNumerator, a function-scope variable

7/4 is an exception where I think [[2, 8]] makes sense.