### PR TITLE
Safer whitespace split for TinyNotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music21j",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "description": "A toolkit for computer-aided musicology, Javascript version",
   "main": "releases/music21.debug.js",
   "typings": "releases/src/main.d.ts",

--- a/src/tinyNotation.ts
+++ b/src/tinyNotation.ts
@@ -72,7 +72,8 @@ export function TinyNotation(textIn: string): stream.Part|stream.Score {
         textIn = textIn.slice(14);
     }
 
-    const tokens: string[] = textIn.split(/\s+/);
+    // whitespace that is not non-breaking space.
+    const tokens: string[] = textIn.split(/[ \t\r\n]+/);
 
     let optionalScore: stream.Score;
 

--- a/tests/moduleTests/tinyNotation.ts
+++ b/tests/moduleTests/tinyNotation.ts
@@ -9,4 +9,20 @@ export default function tests() {
         const p = music21.tinyNotation.TinyNotation('tinyNotation: fn1');
         assert.equal(p.recurse().notes.length, 1);
     });
+
+    test('music21.tinyNotation.TinyNotation split space length', assert => {
+        const tn = (s: string) => {
+            const p = music21.tinyNotation.TinyNotation(s);
+            return p.recurse().notes.length;
+        };
+
+        assert.equal(tn('C4'), 1);
+        assert.equal(tn('C4 D'), 2);
+        assert.equal(tn('C4     D'), 2);
+        assert.equal(tn('C4_hi there'), 1);
+        assert.equal(tn('C4_hi there D'), 2);
+        assert.equal(tn('C4\nD4'), 2);
+        assert.equal(tn('C4\tD4'), 2);
+        assert.equal(tn('C4 partBreak D4'), 2);
+    });
 }


### PR DESCRIPTION
Allow whitespace besides non-breaking space (Breaking a use case inside comments/lyrics/etc.

in theory should be
`/[ \t\r\n\f\v\u2028\u2029]/g` but who uses form feeds or vertical tabs?

