### PR TITLE
SVG length scales with scaleFactor

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -2474,6 +2474,8 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
      * if height is undefined  will use
      *     `this.renderOptions.height`. If still undefined, will use
      *     `this.estimateStreamHeight()`
+     *
+     * Estimated widths and heights are multiplied by this.renderOptions.scaleFactor.
      */
     createNewDOM(
         width?: number|string,
@@ -2504,7 +2506,10 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
             const computedWidth
                 = this.estimateStaffLength()
                 + this.renderOptions.staffPadding;
-            newCanvasOrDIV.setAttribute('width', computedWidth.toString());
+            newCanvasOrDIV.setAttribute(
+                'width',
+                (computedWidth * this.renderOptions.scaleFactor.x).toString()
+            );
         }
         if (height !== undefined) {
             newCanvasOrDIV.setAttribute('height', height.toString());

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -442,6 +442,26 @@ export default function tests() {
         assert.ok(true);
     });
 
+    test('music21.stream.Stream.createNewDOM', assert => {
+        const s = music21.tinyNotation.TinyNotation('4/4 c2 c2 c2 c2');
+        s.renderOptions.scaleFactor = {x: 1.0, y: 1.0};
+
+        const where1 = s.createNewDOM();
+        const full_height = parseInt(where1.getAttribute('height'));
+        const full_width = parseInt(where1.getAttribute('width'));
+
+        // sanity check
+        assert.ok(full_height > 0);
+        assert.ok(full_width > 0);
+
+        s.renderOptions.scaleFactor = {x: 0.5, y: 0.5};
+        const where2 = s.createNewDOM();
+        const half_height = parseInt(where2.getAttribute('height'));
+        const half_width = parseInt(where2.getAttribute('width'));
+        assert.equal(full_height / 2, half_height);
+        assert.equal(full_width / 2, half_width);
+    });
+
     test('music21.stream.Stream.getElementsByClass', assert => {
         const s = new music21.stream.Stream();
         const n1 = new music21.note.Note('C#5');


### PR DESCRIPTION
`Stream.createNewDOM()` adjusts the computed height of the div based on `this.renderOptions.scaleFactor.y`. We should do the same with the computed width (with `this.renderOptions.scaleFactor.x`). Without this adjustment, extra space appears to the right of the staff when `scaleFactor.x < 1.0`.