### PR TITLE
Document broken problems

### DIFF
--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -1206,4 +1206,24 @@ export default function tests() {
         assert.deepEqual(s.noteElementFromScaledX(122), n2);
         assert.deepEqual(s.noteElementFromScaledX(123), n2);
     });
+
+    /**
+     * Similar to makeAccidentals multimeasure but doing it implicitly, and
+     * with naturals
+     */
+    test('music21.stream - makeNotation via vexflow renderer works', assert => {
+        const n1 = new music21.note.Note('F#4');
+        const m1 = new music21.stream.Measure();
+        m1.append(n1);
+        const n2 = new music21.note.Note('F4');
+        const m2 = new music21.stream.Measure();
+        m2.append(n2);
+        const p = new music21.stream.Part();
+        p.append(m1);
+        p.append(m2);
+        p.appendNewDOM();  // TODO -- use fixture and clean up...
+        assert.ok(n1.pitch.accidental?.displayStatus, 'F# has an accidental displayed');
+        // NOPE: not displaying!
+        assert.ok(n2.pitch.accidental?.displayStatus, 'F natural got an accidental and it is displayed');
+    });
 }


### PR DESCRIPTION
Create tests that show where makeNotation is currently broken.  -- to merge into better-accidentals-vexflow branch (#289) to prove that that branch fixes the problems (or doesn't...)

Failing currently.

leads to problems like this, where the second C should be a C-natural.

<img width="416" height="254" alt="Screenshot 2026-02-09 at 16 36 36" src="https://github.com/user-attachments/assets/44826b56-5271-4d4c-987f-e3b7932a35af" />
