### PR TITLE
Bar Standardize vfShow and Bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,15 @@ To run the full test suite headlessly:
 ```sh
 $ npm test
 ```
+
 This will:
 	•	start a Vite development server
 	•	run QUnit tests in headless Chromium
 	•	fail with detailed assertion output if any test fails
+
+(Note that the first time you run you will need to install a headless Chrome 200MB
+with `npx playwright install chromium`)
+
 
 To run tests with the Vite server already running:
 

--- a/src/bar.ts
+++ b/src/bar.ts
@@ -10,9 +10,22 @@ import * as base from './base';
 import { Music21Exception } from './exceptions21';
 
 const barTypeList = [
-    'regular', 'dotted', 'dashed', 'heavy', 'double', 'final',
-    'heavy-light', 'heavy-heavy', 'tick', 'short', 'none',
+    'regular',
+    // 'single', // Deprecated alias for 'regular',
+    'dotted',
+    'dashed',
+    'heavy',
+    'double',
+    // 'end',  // Deprecated alias for 'final',
+    'final',
+    'heavy-light',
+    'heavy-heavy',
+    'tick',
+    'short',
+    'none',
 ];
+
+// MusicXML Barline names
 const barTypeDict = {
     'light-light': 'double',
     'light-heavy': 'final',
@@ -33,8 +46,13 @@ function typeToMusicXMLBarStyle(value: string): string {
     }
 }
 
-function standardizeBarType(value: string='regular'): string {
+export function standardizeBarType(value: string='regular'): string {
     value = value.toLowerCase();
+    if (value === 'end') {
+        value = 'final';
+    } else if (value === 'single') {
+        value = 'regular';
+    }
 
     if (barTypeList.includes(value)) {
         return value;

--- a/src/renderOptions.ts
+++ b/src/renderOptions.ts
@@ -11,6 +11,7 @@
  *
  */
 import {StaveConnector} from './types';
+import {standardizeBarType} from './bar';
 
 interface EventInterface {
     click: string|Function|undefined,
@@ -64,8 +65,8 @@ export class RenderOptions {
     // scaleFactors.
     maxSystemWidth: number = undefined;
 
-    leftBarline: string = undefined;  // render() sets to 'none' for system beginnings
-    rightBarline: string = undefined;
+    _leftBarline: string = undefined;  // render() sets to 'none' for system beginnings
+    _rightBarline: string = undefined;
 
     staffLines: number = 5;
     staffConnectors: StaveConnector[] = [StaveConnector.SINGLE, StaveConnector.BRACE];
@@ -92,6 +93,28 @@ export class RenderOptions {
         return this.heightAboveStaff + this.heightOfStaffProper + this.heightBelowStaff;
     }
 
+    get leftBarline(): string|undefined {
+        return this._leftBarline;
+    }
+
+    set leftBarline(b: string|undefined) {
+        if (b === undefined) {
+            this._leftBarline = undefined;
+        }
+        this._leftBarline = standardizeBarType(b);
+    }
+
+    get rightBarline(): string|undefined {
+        return this._rightBarline;
+    }
+
+    set rightBarline(b: string|undefined) {
+        if (b === undefined) {
+            this._rightBarline = undefined;
+        }
+        this._rightBarline = standardizeBarType(b);
+    }
+
     deepClone(): RenderOptions {
         // TODO(MSC): allow for subclassing...
         const out = new RenderOptions();
@@ -104,7 +127,7 @@ export class RenderOptions {
         out.scaleFactor.x = this.scaleFactor.x;
         out.scaleFactor.y = this.scaleFactor.y;
         out.staffConnectors = [...this.staffConnectors];
-        out.events = {...this.events};
+        out.events = {...this.events};  // Q: Should the events themselves be cloned?
         return out;
     }
 }

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -40,12 +40,14 @@ import type * as renderOptions from './renderOptions';
 import type {Tuplet} from './duration';
 import {StaveConnector} from './types';
 
-const barlineMap = {
-    single: 'SINGLE',
+export const barline_m21ToVexflow = {
+    regular: 'SINGLE',
+    single: 'SINGLE',  // deprecated alias for regular
     double: 'DOUBLE',
-    end: 'END',
+    final: 'END',
+    end: 'END',  // deprecated alias for final
     none: 'NONE',
-    // TODO: Repeats
+    // TODO: Repeats? -- No, let's move to real Barline objects like M21P
 };
 
 export const vexflowDefaults = {
@@ -728,15 +730,15 @@ export class Renderer {
      * adds keySignature, timeSignature, and rightBarline
      *
      * RenderOptions object might have
-     * `{showMeasureNumber: boolean, rightBarLine/leftBarline: string<{'single', 'double', 'end', 'none'}>}`
+     * `{showMeasureNumber: boolean,
+     *   rightBarLine/leftBarline: ['regular'|undefined, 'double', 'final', 'none']`
      */
     setClefEtc(s: stream.Stream, stave: VFStave, rendOp?: renderOptions.RenderOptions) {
         if (rendOp === undefined) {
             rendOp = s.renderOptions;
         }
 
-        let sClef = s.getSpecialContext('clef')
-            || s.getContextByClass('Clef');
+        let sClef = s.getSpecialContext('clef') || s.getContextByClass('Clef');
 
         // this should not be necessary now that derivation is
         // checked, but does not hurt.
@@ -801,7 +803,7 @@ export class Renderer {
         if (rendOp.leftBarline !== undefined) {
             const bl = rendOp.leftBarline;
 
-            const vxBL:string = barlineMap[bl];
+            const vxBL: string = barline_m21ToVexflow[bl];
             if (vxBL !== undefined) {
                 stave.setBegBarType(VFBarlineType[vxBL]);
             }
@@ -810,7 +812,7 @@ export class Renderer {
         if (rendOp.rightBarline !== undefined) {
             const bl = rendOp.rightBarline;
 
-            const vxBL:string = barlineMap[bl];
+            const vxBL: string = barline_m21ToVexflow[bl];
             if (vxBL !== undefined) {
                 stave.setEndBarType(VFBarlineType[vxBL]);
             }

--- a/tests/loadAll.ts
+++ b/tests/loadAll.ts
@@ -1,6 +1,7 @@
 import * as QUnit from 'qunit';
 
 import articulations from './moduleTests/articulations';
+import bar from './moduleTests/bar';
 import base from './moduleTests/base';
 import beam from './moduleTests/beam';
 import chord from './moduleTests/chord';
@@ -32,6 +33,7 @@ import * as music21 from '../src/main';
 
 const allTests = {
     articulations,
+    bar,
     base,
     beam,
     chord,

--- a/tests/moduleTests/bar.ts
+++ b/tests/moduleTests/bar.ts
@@ -1,0 +1,32 @@
+import * as QUnit from 'qunit';
+import * as music21 from '../../src/main';
+
+const { test } = QUnit;
+
+
+export default function tests() {
+    test('music21.bar.standardizeBarType', assert => {
+        const { standardizeBarType } = music21.bar;
+
+        assert.equal(standardizeBarType(), 'regular', 'default barline is regular');
+        assert.equal(standardizeBarType('single'), 'regular', 'deprecated single alias maps to regular');
+        assert.equal(standardizeBarType('end'), 'final', 'deprecated end alias maps to final');
+        assert.equal(standardizeBarType('light-light'), 'double', 'MusicXML light-light maps to double');
+        assert.equal(standardizeBarType('light-heavy'), 'final', 'MusicXML light-heavy maps to final');
+        assert.equal(standardizeBarType('FINAL'), 'final', 'capitalization is normalized');
+
+        assert.throws(() => {
+            standardizeBarType('not-a-barline');
+        }, /cannot process style/, 'invalid styles throw BarException');
+    });
+
+    test('music21.bar.Barline normalizes deprecated aliases', assert => {
+        const single = new music21.bar.Barline('single');
+        assert.equal(single.type, 'regular', 'single barline stores regular type');
+        assert.equal(single.musicXMLBarStyle(), 'regular', 'regular barline exports as regular');
+
+        const end = new music21.bar.Barline('end');
+        assert.equal(end.type, 'final', 'end barline stores final type');
+        assert.equal(end.musicXMLBarStyle(), 'light-heavy', 'final barline exports as light-heavy');
+    });
+}


### PR DESCRIPTION
renderOptions/vfShow was using barline types "single" and "end".

Music21 uses "regular" and "final"

Standardize to music21 but keep older aliases