### PR TITLE
Instrument and Soundfont loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ support for MIDI devices.
 ## Documentation
 
 This README appears in both the GitHub home page and the documentation
-home page; currently building docs is broken
+home page; currently building docs is broken.
 
 Begin at the {@link music21} namespace (click the link or use the
 menu above), or start with
@@ -35,6 +35,17 @@ a specific one such as {@link music21.note} or {@link music21.stream}
 or a Class such as {@link music21.note.Note} or {@link music21.stream.Stream}.
 
 (Ignore “Modules” they’re not useful and duplicate the namespace pages).
+
+## Demo
+
+Demonstrations of music21j are available on Github:
+
+* [Play notes on an on-screen keyboard](https://cuthbertlab.github.io/music21j/testHTML/keyboard.html)
+* [Play w/ MIDI keyboard](https://cuthbertlab.github.io/music21j/testHTML/showKeyboard.html)
+* [Play w/ Music21j in a Sandbox](https://cuthbertlab.github.io/music21j/testHTML/m21jSandbox.html)
+* [MusicXML Parsing](https://cuthbertlab.github.io/music21j/testHTML/musicxmlTest.html)
+* [Instruments setup and switching](https://cuthbertlab.github.io/music21j/testHTML/instruments.html)
+* [Demo loading music21j and soundfonts from elsewhere](https://cuthbertlab.github.io/music21j/testHTML/sfElsewhereCDN.html)
 
 ## Example
 
@@ -184,9 +195,10 @@ To develop, run this npm command:
 ```sh
 $ npm run dev
 ```
-
 and navigate to http://localhost:5173/testHTML to see various tests.
 
+(if sound is not working and stalled on "Loading Instrument" run `npm install` again to
+download soundfonts)
 
 ### Watch / development mode
 
@@ -200,6 +212,19 @@ This starts Vite’s development server with fast rebuilds and live reload.
 (Note that the testHTML files currently reference the hardcoded 
 releases/music21.debug.js file -- they are set up as a playground
 rather than for testing purposes right now; making both possible is a TODO)
+
+## TestHTML in Developing
+
+After running `npm run dev`, try navigating to /testHTML/m21jSandbox-hot-reload.html, such as at:
+http://localhost:5173/testHTML/m21jSandbox-hot-reload.html which will update the output as you
+type, but also reload music21j as you edit it.
+
+For other testHTML files, the paradigm is to use 
+`<script type="module" src="./m21-dev.ts"></script>` while developing (to get hot reload) 
+and then switch to
+`<script src="../releases/music21.debug.js"></script>` when commiting (so that it works on
+`cuthbertLab.github.io/music21j/`)
+
 
 ## Testing
 
@@ -313,6 +338,7 @@ If it looks like there is something to update, run
 $ npx npm-check-updates -u
 $ npm install
 ```
+
 
 ## Changes
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,9 +4,11 @@
  */
 import defaults from './defaults';
 
-export function coerceHTMLElement(el?: JQuery|HTMLElement): HTMLElement {
+export function coerceHTMLElement(el?: JQuery|HTMLElement|string): HTMLElement {
     let htmlElement: HTMLElement;
-    if (el != null && (el as JQuery).jquery !== undefined) {
+    if (typeof el === 'string' && el !== '') {
+        htmlElement = document.querySelector(el);
+    } else if (el != null && (el as JQuery).jquery !== undefined) {
         htmlElement = (el as JQuery)[0];
     } else if (el instanceof HTMLElement) {
         htmlElement = el;
@@ -398,7 +400,14 @@ export const pathSimplify = (path: string): string => {
     const ps = path.split('/');
     const addSlash = (path.slice(path.length - 1, path.length) !== '/');
     const pout = [];
-    for (const el of ps) {
+    for (let i = 0; i < ps.length; i++) {
+        const el = ps[i];
+        // Collapse `//` in the middle of a path (split produces '' segments).
+        // Keep ps[0]='' to preserve a leading '/' for absolute paths,
+        // and ps[last]='' to preserve a trailing '/'.
+        if (el === '' && i !== 0 && i !== ps.length - 1) {
+            continue;
+        }
         if (el === '..') {
             if (pout.length > 0) {
                 if (pout[pout.length - 1] !== '..') {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -2620,12 +2620,6 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
         height: number|string = undefined,
         elementType: string = 'svg'
     ): HTMLDivElement|HTMLCanvasElement {
-        if (!where) {
-            where = defaults.appendLocation;
-        }
-        if (typeof where === 'string') {
-            where = document.querySelector(where) as HTMLElement;
-        }
         const appendElement = common.coerceHTMLElement(where);
         const svgOrCanvasBlock = this.createDOM(width, height, elementType);
         appendElement.appendChild(svgOrCanvasBlock);
@@ -2644,7 +2638,7 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
      * @returns {HTMLDivElement} the svg
      */
     replaceDOM(
-        where?: HTMLElement,
+        where?: HTMLElement|string,
         preserveSvgSize: boolean=false,
         elementType: string='svg'
     ): HTMLElement {

--- a/testHTML/instruments.html
+++ b/testHTML/instruments.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Instrument demos</title>
+    <link rel="stylesheet" href="../css/m21.css">
+    <!-- To activate Hot Reloading uncomment this and comment out the next -->
+     <script type="module" src="./m21-dev.ts"></script>
+<!--    <script src="../releases/music21.debug.js"></script>-->
+    <style>
+        body { font-family: sans-serif; max-width: 820px; margin: 1em auto; padding: 0 1em; }
+        h1 { font-size: 1.4em; }
+        h2 { font-size: 1.1em; margin-top: 2em; }
+        pre {
+            background: #f4f4f4;
+            border-left: 4px solid #88a;
+            padding: 10px 14px;
+            font-size: 13px;
+            overflow-x: auto;
+        }
+        .render { background: #eed; padding: 10px; border: 1px solid #ddc; }
+        .hint { color: #666; font-size: 0.9em; }
+        fieldset { margin: 10px 0; }
+        label { margin-right: 1em; }
+    </style>
+</head>
+<body>
+
+<h1>Loading instruments in music21j</h1>
+
+<p>
+    Call <code>music21.miditools.loadSoundfont(name, callback)</code> with the
+    instrument name. The callback receives an <code>Instrument</code> object you
+    can assign to a stream&rsquo;s <code>.instrument</code> property. The note
+    will play with that sound when the rendered notation is clicked
+    (or when triggered in another way).
+</p>
+
+<h2>Example: clarinet</h2>
+
+<pre id="clarinet-source"></pre>
+
+<div class="render">
+    <div id="mainSVG" class="streamHolding">
+        <svg width="525" height="120"></svg>
+    </div>
+</div>
+<p class="hint">Click the staff to hear it (audio loads after the soundfont arrives).</p>
+
+<h2>Pick another instrument</h2>
+
+<p>Choose one of the soundfonts below; the same C&sharp;5 whole note will be re-rendered with that sound.</p>
+
+<fieldset>
+    <legend>Instrument</legend>
+    <label><input type="radio" name="instr" value="flute"> Flute</label>
+    <label><input type="radio" name="instr" value="banjo"> Banjo</label>
+    <label><input type="radio" name="instr" value="church_organ"> Church organ</label>
+    <label><input type="radio" name="instr" value="cello"> Cello</label>
+</fieldset>
+
+<div id="pickedContainer" class="render">
+    <div class="streamHolding">
+        <svg width="525" height="120"></svg>
+    </div>
+</div>
+<p id="status" class="hint">No instrument selected yet.</p>
+
+<script>
+    // demo page for loading soundfonts.
+    const clarinetSource = `const s = new music21.stream.Measure();
+s.append(new music21.meter.TimeSignature('4/4'));
+const n = new music21.note.Note("B-4");
+n.duration.type = "whole";
+s.append(n);
+music21.miditools.loadSoundfont('clarinet', cl => {
+    s.instrument = cl;
+    s.replaceDOM('#mainSVG');
+});`;
+
+    function runClarinetDemo() {
+        // Show the code on the page.
+        document.getElementById('clarinet-source').textContent = clarinetSource;
+        // Run the same code shown above.
+        const s = new music21.stream.Measure();
+        s.append(new music21.meter.TimeSignature('4/4'));
+        const n = new music21.note.Note('B-4');
+        n.duration.type = 'whole';
+        s.append(n);
+        music21.miditools.loadSoundfont('clarinet', cl => {
+            s.instrument = cl;
+            s.replaceDOM('#mainSVG');
+        });
+    }
+
+    // AI-assisted: render a single whole note on the chosen instrument.
+    let s2 = undefined;
+
+    function renderWithInstrument(instrumentName) {
+        const status = document.getElementById('status');
+        status.textContent = 'Loading ' + instrumentName + '…';
+        if (s2 === undefined) {
+            s2 = new music21.stream.Measure();
+            s2.append(new music21.meter.TimeSignature('4/4'));
+            const n = new music21.note.Note('C#5');
+            n.duration.type = 'whole';
+            s2.append(n);
+        } // otherwise reuse same score and note object.
+        music21.miditools.loadSoundfont(instrumentName, inst => {
+            s2.instrument = inst;
+            s2.replaceDOM('#pickedContainer');
+            status.textContent = 'Playing on ' + instrumentName.replace(/_/g, ' ')
+                + '. Click the staff to play.';
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        runClarinetDemo();
+        for (const radio of document.querySelectorAll('input[name="instr"]')) {
+            radio.addEventListener('change', e => {
+                renderWithInstrument(e.target.value);
+            });
+        }
+    });
+</script>
+
+</body>
+</html>

--- a/testHTML/m21jSandbox.html
+++ b/testHTML/m21jSandbox.html
@@ -76,8 +76,6 @@ s.append(n3);
 s.renderOptions.marginBottom = 80;
 s.replaceDOM('#mainSVG');
     `;
-
-    const mainSVG = document.querySelector("#mainSVG");
     const msg = document.querySelector('div.editor-error .text');
     const sandbox = document.querySelector("#sandbox");
     const localStorageKey = 'm21j_sandbox_code';

--- a/tests/moduleTests/common.ts
+++ b/tests/moduleTests/common.ts
@@ -52,5 +52,24 @@ export default function tests() {
         assert.equal(common.pathSimplify(url), url);
         const urlWithoutTrailingSlash = url.substring(0, url.length - 1);
         assert.equal(common.pathSimplify(urlWithoutTrailingSlash), url);
+
+        // Internal `//` should collapse to a single `/`.
+        // Regression: m21basePath '../' joined with '/soundfonts/...' yielded
+        // '..//soundfonts/...', which then resolved to URLs like
+        // 'http://localhost:5173//soundfonts/...'.
+        assert.equal(
+            common.pathSimplify('..//soundfonts/midi-js-soundfonts-master/FluidR3_GM/'),
+            '../soundfonts/midi-js-soundfonts-master/FluidR3_GM/'
+        );
+        assert.equal(common.pathSimplify('/foo//bar/'), '/foo/bar/');
+        assert.equal(common.pathSimplify('foo///bar'), 'foo/bar/');
+
+        // Protocol-prefixed URLs keep their `://` and collapse only the body.
+        assert.equal(
+            common.pathSimplify('https://example.com//a//b/'),
+            'https://example.com/a/b/'
+        );
+        // Protocol-relative (CDN) prefix is preserved.
+        assert.equal(common.pathSimplify('//cdn.example.com//a/'), '//cdn.example.com/a/');
     });
 }


### PR DESCRIPTION
Fix errors with instruments's sound fonts having extra slashes that throw errors on the vite server.  Add an instruments.html test.  Link testHTML files from the repo finally!

Apparently the long documented replaceDOM('#mainDiv') was not working -- let coerceHTML also deal with strings -- a tiny piece of safety (like the old JQuery safety)