### PR TITLE
Fix xmlForward offset calculation

### DIFF
--- a/src/musicxml/xmlToM21.ts
+++ b/src/musicxml/xmlToM21.ts
@@ -694,7 +694,7 @@ export class MeasureParser {
     xmlForward(mxForward: Element) {
         const mxDuration = mxForward.querySelector('duration');
         const change = parseFloat(mxDuration.textContent.trim()) / this.divisions;
-        this.offsetMeasureNote += Math.min(opFrac(change), 0.0);
+        this.offsetMeasureNote += Math.max(opFrac(change), 0.0);
     }
 
     // xmlGraceToGrace

--- a/src/musicxml/xmlToM21.ts
+++ b/src/musicxml/xmlToM21.ts
@@ -688,13 +688,15 @@ export class MeasureParser {
     xmlBackup(mxBackup: Element) {
         const mxDuration = mxBackup.querySelector('duration');
         const change = parseFloat(mxDuration.textContent.trim()) / this.divisions;
-        this.offsetMeasureNote -= Math.max(opFrac(change), 0.0);
+        this.offsetMeasureNote -= opFrac(change);
+        this.offsetMeasureNote = Math.max(this.offsetMeasureNote, 0.0);
     }
 
     xmlForward(mxForward: Element) {
         const mxDuration = mxForward.querySelector('duration');
         const change = parseFloat(mxDuration.textContent.trim()) / this.divisions;
-        this.offsetMeasureNote += Math.max(opFrac(change), 0.0);
+        // Allow overfilled measures for now -- someday: warn?
+        this.offsetMeasureNote += opFrac(change);
     }
 
     // xmlGraceToGrace


### PR DESCRIPTION
Finally debugged why I had funny ties in piano parts: I had incorrect offsets after a `<forward>`.

Looking again, I don't think these two `.max()` calls are even needed: I don't think we have to protect against negative values here. I can remove if you prefer. EDIT: I checked m21p and updated to match its behavior here (from https://github.com/cuthbertLab/music21/pull/972)