### PR TITLE
Simplify multiple enharmonics

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -95,9 +95,7 @@ export class Music21Object extends prebase.ProtoM21Object {
             newObj.sites = new sites.Sites();
         };
 
-        // A `_cache` (on Chord, and any future subclass such as Stream) holds
-        // derived/memoized data; the clone must start with its own fresh cache
-        // from its constructor rather than sharing the original's by reference.
+        // clones start with fresh cache (constructor = {} or new Map, etc.)
         this._cloneCallbacks._cache = 'constructor';
     }
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -94,6 +94,11 @@ export class Music21Object extends prebase.ProtoM21Object {
         ) => {
             newObj.sites = new sites.Sites();
         };
+
+        // A `_cache` (on Chord, and any future subclass such as Stream) holds
+        // derived/memoized data; the clone must start with its own fresh cache
+        // from its constructor rather than sharing the original's by reference.
+        this._cloneCallbacks._cache = 'constructor';
     }
 
     /**

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -65,6 +65,22 @@ export class Chord extends note.NotRest {
                 ? this._notes.map(n => n.clone(true, memo))
                 : [...this._notes];
         };
+        // _overrides (e.g. an overridden root) must be copied into a new object
+        // so the clone does not share it by reference; a deep clone also clones
+        // any music21-object values. AI-assisted.
+        this._cloneCallbacks._overrides = (
+            keyName: string,
+            newObj: Chord,
+            deep: boolean,
+            memo: WeakMap<any, any>,
+        ) => {
+            const copied: any = {};
+            for (const k of Object.keys(this._overrides)) {
+                const v = this._overrides[k];
+                copied[k] = (deep && v?.isProtoM21Object) ? v.clone(true, memo) : v;
+            }
+            newObj._overrides = copied;
+        };
 
         let arrayNotes: Array<string|note.Note|pitch.Pitch>;
         if (typeof notes === 'undefined') {

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -17,9 +17,10 @@ import * as note from './note';
 import * as chordTables from './chordTables';
 
 // imports for typing
+import * as pitch from './pitch';
 import type * as clef from './clef';
 import type * as instrument from './instrument';
-import type * as pitch from './pitch';
+import type * as key from './key';
 import {VexflowNoteOptions} from './note';
 
 export { chordTables };
@@ -372,6 +373,50 @@ export class Chord extends note.NotRest {
         }
         const closedChord = new Chord(nonDuplicatingPitches);
         return closedChord;
+    }
+
+    /**
+     * Calls `pitch.simplifyMultipleEnharmonics` on the pitches of the chord.
+     *
+     * Simplifies the enharmonics in the sense of making a more logical chord.
+     * Note below that E# is added there because C# major is simpler than
+     * C# F G#.
+     *
+     * If `keyContext` is provided the enharmonics are simplified based on the
+     * supplied Key or KeySignature.
+     *
+     * AI-assisted (port of music21p Chord.simplifyEnharmonics).
+     *
+     * @example
+     * const c = new music21.chord.Chord('C# F G#');
+     * c.simplifyEnharmonics(true);
+     * c.pitches.map(p => p.name);
+     * // ['C#', 'E#', 'G#']
+     */
+    simplifyEnharmonics(
+        inPlace=false,
+        keyContext?: key.KeySignature
+    ): Chord {
+        const returnObj = inPlace ? this : this.clone(true);
+        const pitches = pitch.simplifyMultipleEnharmonics(
+            returnObj.pitches, undefined, keyContext
+        );
+        if (inPlace) {
+            for (let i = 0; i < pitches.length; i++) {
+                returnObj._notes[i].pitch = pitches[i];
+            }
+        } else {
+            // Chord.clone() shares the underlying notes array, so build a fresh
+            // set of notes and install it to avoid mutating the original chord.
+            const newNotes = returnObj._notes.map((n, i) => {
+                const newNote = n.clone(true);
+                newNote.pitch = pitches[i].clone(true);
+                return newNote;
+            });
+            returnObj.notes = newNotes;
+        }
+        returnObj._cache = {};
+        return returnObj;
     }
 
     /**

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -51,10 +51,7 @@ export class Chord extends note.NotRest {
 
     constructor(notes?: string|string[]|note.Note|note.Note[]|pitch.Pitch|pitch.Pitch[]) {
         super();
-        // The base clone() only deep-copies ProtoM21Object-valued properties, so
-        // the _notes Array would otherwise be shared by reference.  A deep clone
-        // must copy each Note; a shallow clone keeps the same Notes but in a new
-        // array. AI-assisted.
+        // Shallow clone shares Notes but gets a new _notes array.
         this._cloneCallbacks._notes = (
             keyName: string,
             newObj: Chord,
@@ -65,9 +62,7 @@ export class Chord extends note.NotRest {
                 ? this._notes.map(n => n.clone(true, memo))
                 : [...this._notes];
         };
-        // _overrides (e.g. an overridden root) must be copied into a new object
-        // so the clone does not share it by reference; a deep clone also clones
-        // any music21-object values. AI-assisted.
+        // _overrides (e.g. an overridden root) are shared on shallow clone, but the Array is not.
         this._cloneCallbacks._overrides = (
             keyName: string,
             newObj: Chord,
@@ -415,8 +410,6 @@ export class Chord extends note.NotRest {
      *
      * If `keyContext` is provided the enharmonics are simplified based on the
      * supplied Key or KeySignature.
-     *
-     * AI-assisted (port of music21p Chord.simplifyEnharmonics).
      *
      * @example
      * const c = new music21.chord.Chord('C# F G#');

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -51,6 +51,21 @@ export class Chord extends note.NotRest {
 
     constructor(notes?: string|string[]|note.Note|note.Note[]|pitch.Pitch|pitch.Pitch[]) {
         super();
+        // The base clone() only deep-copies ProtoM21Object-valued properties, so
+        // the _notes Array would otherwise be shared by reference.  A deep clone
+        // must copy each Note; a shallow clone keeps the same Notes but in a new
+        // array. AI-assisted.
+        this._cloneCallbacks._notes = (
+            keyName: string,
+            newObj: Chord,
+            deep: boolean,
+            memo: WeakMap<any, any>,
+        ) => {
+            newObj._notes = deep
+                ? this._notes.map(n => n.clone(true, memo))
+                : [...this._notes];
+        };
+
         let arrayNotes: Array<string|note.Note|pitch.Pitch>;
         if (typeof notes === 'undefined') {
             arrayNotes = [];
@@ -401,19 +416,8 @@ export class Chord extends note.NotRest {
         const pitches = pitch.simplifyMultipleEnharmonics(
             returnObj.pitches, undefined, keyContext
         );
-        if (inPlace) {
-            for (let i = 0; i < pitches.length; i++) {
-                returnObj._notes[i].pitch = pitches[i];
-            }
-        } else {
-            // Chord.clone() shares the underlying notes array, so build a fresh
-            // set of notes and install it to avoid mutating the original chord.
-            const newNotes = returnObj._notes.map((n, i) => {
-                const newNote = n.clone(true);
-                newNote.pitch = pitches[i].clone(true);
-                return newNote;
-            });
-            returnObj.notes = newNotes;
+        for (let i = 0; i < pitches.length; i++) {
+            returnObj._notes[i].pitch = pitches[i];
         }
         returnObj._cache = {};
         return returnObj;

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -430,7 +430,7 @@ export class Chord extends note.NotRest {
     ): Chord {
         const returnObj = inPlace ? this : this.clone(true);
         const pitches = pitch.simplifyMultipleEnharmonics(
-            returnObj.pitches, undefined, keyContext
+            returnObj.pitches, { keyContext }
         );
         for (let i = 0; i < pitches.length; i++) {
             returnObj._notes[i].pitch = pitches[i];

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -9,11 +9,14 @@
  *
  */
 import { debug } from './debug';
+import { Music21Exception } from './exceptions21';
 
 import * as common from './common';
 import * as note from './note';
 import * as prebase from './prebase';
 import * as pitch from './pitch';
+
+export class IntervalException extends Music21Exception {}
 
 /**
  * Interval Directions as an Object/map
@@ -759,13 +762,10 @@ export function convertDiatonicNumberToStep(
     let octave: number;
     if (dn === 0) {
         return ['B', -1];
-    } else if (dn > 0) {
+    } else {
+        // floor division keeps this correct for low (negative) notes too.
         octave = Math.floor((dn - 1) / 7);
         stepNumber = dn - 1 - octave * 7;
-    } else {
-        // low notes... test, because js(floor) != py(int);
-        octave = Math.floor(dn / 7);
-        stepNumber = dn - 1 - (octave + 1) * 7;
     }
     const stepName = IntervalStepNames[stepNumber];
     return [stepName, octave];
@@ -1098,4 +1098,113 @@ export function add(intervalList: Interval[]): Interval {
         p2 = i.transposePitch(p2);
     }
     return new Interval(p1, p2);
+}
+
+/**
+ * A pythagorean ratio, expressed as a reduced numerator and denominator.
+ *
+ * music21p returns a Python `Fraction`; JavaScript has no rational type,
+ * so `intervalToPythagoreanRatio` returns this simple object instead.
+ */
+export interface PythagoreanRatio {
+    numerator: number,
+    denominator: number,
+}
+
+// keyed by the name of the target pitch reached from C1; caches the found
+// pitch together with the ratio expressed as exponents of 2 and 3, since a
+// pythagorean ratio is always of the form 2 ** twoExp * 3 ** threeExp.
+const _pythagoreanCache: Record<string, [pitch.Pitch, number, number]> = {};
+
+/**
+ * Returns the interval ratio in pythagorean tuning as a reduced
+ * {@link PythagoreanRatio} (music21p returns a `Fraction`).
+ *
+ * Throws an {@link IntervalException} if no ratio can be found, such as for
+ * quarter tones.
+ *
+ * AI-assisted (port of music21p interval.intervalToPythagoreanRatio).
+ *
+ * @example
+ * const i = new music21.interval.Interval('P5');
+ * music21.interval.intervalToPythagoreanRatio(i);
+ * // { numerator: 3, denominator: 2 }
+ */
+export function intervalToPythagoreanRatio(intervalObj: Interval): PythagoreanRatio {
+    const startPitch = new pitch.Pitch('C1');
+    let endPitchWanted: pitch.Pitch;
+    try {
+        endPitchWanted = intervalObj.transposePitch(startPitch);
+    } catch (e) {
+        // m21j throws when the spelling exceeds quadruple accidentals, where
+        // music21p would wrap; treat such intervals as having no ratio.
+        if (e instanceof Music21Exception) {
+            throw new IntervalException(
+                `Could not find a pythagorean ratio for ${intervalObj.name}.`
+            );
+        }
+        throw e;
+    }
+
+    let endPitch: pitch.Pitch;
+    // ratio = 2 ** twoExp * 3 ** threeExp
+    let twoExp: number;
+    let threeExp: number;
+
+    if (endPitchWanted.name in _pythagoreanCache) {
+        [endPitch, twoExp, threeExp] = _pythagoreanCache[endPitchWanted.name];
+    } else {
+        // A side is set to null once it overflows m21j's accidental range
+        // (music21p instead wraps the spelling); the target is always reached
+        // first on the other, nearer side.
+        let endPitchUp: pitch.Pitch|null = startPitch;
+        let endPitchDown: pitch.Pitch|null = startPitch;
+        const upFifth = new Interval('P5');
+        const downFifth = new Interval('-P5');
+        let found = false;
+
+        // when counter reaches 37 we have exhausted the reachable spellings
+        for (let counter = 0; counter < 37; counter++) {
+            if (endPitchUp !== null && endPitchUp.name === endPitchWanted.name) {
+                threeExp = counter;  // (3 / 2) ** counter
+                twoExp = -counter;
+                endPitch = endPitchUp;
+                found = true;
+                break;
+            } else if (endPitchDown !== null && endPitchDown.name === endPitchWanted.name) {
+                threeExp = -counter;  // (2 / 3) ** counter
+                twoExp = counter;
+                endPitch = endPitchDown;
+                found = true;
+                break;
+            } else {
+                try {
+                    endPitchUp = endPitchUp && upFifth.transposePitch(endPitchUp);
+                } catch (e) {
+                    if (!(e instanceof Music21Exception)) { throw e; }
+                    endPitchUp = null;
+                }
+                try {
+                    endPitchDown = endPitchDown && downFifth.transposePitch(endPitchDown);
+                } catch (e) {
+                    if (!(e instanceof Music21Exception)) { throw e; }
+                    endPitchDown = null;
+                }
+            }
+        }
+        if (!found) {
+            throw new IntervalException(
+                `Could not find a pythagorean ratio for ${intervalObj.name}.`
+            );
+        }
+        _pythagoreanCache[endPitchWanted.name] = [endPitch, twoExp, threeExp];
+    }
+
+    // multiply the ratio by (2 / 1) ** octaves
+    const octaves = Math.trunc((endPitchWanted.ps - endPitch.ps) / 12);
+    twoExp += octaves;
+    // 2 and 3 are coprime, so splitting by sign gives an already-reduced fraction
+    const numerator = 2 ** Math.max(0, twoExp) * 3 ** Math.max(0, threeExp);
+    const denominator = 2 ** Math.max(0, -twoExp) * 3 ** Math.max(0, -threeExp);
+    return { numerator, denominator };
 }

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -758,15 +758,10 @@ export const IntervalStepNames = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
 export function convertDiatonicNumberToStep(
     dn: number
 ): [string, number] {
-    let stepNumber: number;
-    let octave: number;
-    if (dn === 0) {
-        return ['B', -1];
-    } else {
-        // floor division keeps this correct for low (negative) notes too.
-        octave = Math.floor((dn - 1) / 7);
-        stepNumber = dn - 1 - octave * 7;
-    }
+    // floor division keeps this correct for low (dn <= 0) notes too, e.g.
+    // dn = 0 -> ['B', -1] and dn = -1 -> ['A', -1].
+    const octave = Math.floor((dn - 1) / 7);
+    const stepNumber = dn - 1 - octave * 7;
     const stepName = IntervalStepNames[stepNumber];
     return [stepName, octave];
 }

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -758,8 +758,6 @@ export const IntervalStepNames = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
 export function convertDiatonicNumberToStep(
     dn: number
 ): [string, number] {
-    // floor division keeps this correct for low (dn <= 0) notes too, e.g.
-    // dn = 0 -> ['B', -1] and dn = -1 -> ['A', -1].
     const octave = Math.floor((dn - 1) / 7);
     const stepNumber = dn - 1 - octave * 7;
     const stepName = IntervalStepNames[stepNumber];
@@ -1096,7 +1094,7 @@ export function add(intervalList: Interval[]): Interval {
 }
 
 /**
- * A pythagorean ratio, expressed as a reduced numerator and denominator.
+ * A Pythagorean ratio, expressed as a reduced numerator and denominator.
  *
  * music21p returns a Python `Fraction`; JavaScript has no rational type,
  * so `intervalToPythagoreanRatio` returns this simple object instead.
@@ -1118,8 +1116,6 @@ const _pythagoreanCache: Record<string, [pitch.Pitch, number, number]> = {};
  * Throws an {@link IntervalException} if no ratio can be found, such as for
  * quarter tones.
  *
- * AI-assisted (port of music21p interval.intervalToPythagoreanRatio).
- *
  * @example
  * const i = new music21.interval.Interval('P5');
  * music21.interval.intervalToPythagoreanRatio(i);
@@ -1135,7 +1131,7 @@ export function intervalToPythagoreanRatio(intervalObj: Interval): PythagoreanRa
         // music21p would wrap; treat such intervals as having no ratio.
         if (e instanceof Music21Exception) {
             throw new IntervalException(
-                `Could not find a pythagorean ratio for ${intervalObj.name}.`
+                `Could not find a Pythagorean ratio for ${intervalObj.name}.`
             );
         }
         throw e;
@@ -1189,7 +1185,7 @@ export function intervalToPythagoreanRatio(intervalObj: Interval): PythagoreanRa
         }
         if (!found) {
             throw new IntervalException(
-                `Could not find a pythagorean ratio for ${intervalObj.name}.`
+                `Could not find a Pythagorean ratio for ${intervalObj.name}.`
             );
         }
         _pythagoreanCache[endPitchWanted.name] = [endPitch, twoExp, threeExp];

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -1358,7 +1358,7 @@ function _greedyEnharmonicsSearch(
  * A function can be passed as the `criterion` argument; it is minimized in a
  * greedy, left-to-right fashion.
  *
- * The `keyContext` argument supplies a KeySignature or Key used in the
+ * The `keyContext` option supplies a KeySignature or Key used in the
  * simplification.  Note that without a key context we will not simplify
  * everything.
  *
@@ -1367,11 +1367,15 @@ function _greedyEnharmonicsSearch(
  * @example
  * music21.pitch.simplifyMultipleEnharmonics([11, 3, 6]).map(p => p.name);
  * // ['B', 'D#', 'F#']
+ * @example
+ * music21.pitch.simplifyMultipleEnharmonics([6, 10, 1], {keyContext: new key.Key('B')});
  */
 export function simplifyMultipleEnharmonics(
     pitches: Iterable<Pitch|string|number>,
-    criterion: (pitches: Pitch[]) => number = _dissonanceScore,
-    keyContext?: key.KeySignature
+    { criterion=_dissonanceScore, keyContext }: {
+        criterion?: (pitches: Pitch[]) => number,
+        keyContext?: key.KeySignature,
+    } = {}
 ): Pitch[] {
     let oldPitches = Array.from(pitches).map(
         p => (p instanceof Pitch ? p : new Pitch(p))

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -1213,9 +1213,11 @@ function _product<T>(pools: T[][]): T[][] {
  */
 function _dissonanceScore(
     pitches: Pitch[],
-    smallPythagoreanRatio=true,
-    accidentalPenalty=true,
-    triadAward=true
+    { smallPythagoreanRatio=true, accidentalPenalty=true, triadAward=true }: {
+        smallPythagoreanRatio?: boolean,
+        accidentalPenalty?: boolean,
+        triadAward?: boolean,
+    } = {}
 ): number {
     let scoreAccidentals = 0.0;
     let scoreRatio = 0.0;

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -1264,8 +1264,7 @@ function _dissonanceScore(
                 const ratio = interval.intervalToPythagoreanRatio(thisInterval);
                 // The constant is 1 / ln(3**12): it normalizes the penalty so a
                 // diminished second (the Pythagorean comma, whose ratio denominator
-                // is 3**12 = 531441) scores exactly 1.0. (music21p carries it as the
-                // bare literal 0.07585326888, formerly 2 * 0.03792663444.)
+                // is 3**12 = 531441) scores exactly 1.0.
                 const penalty = Math.log(ratio.denominator) * 0.07585326888;
                 scoreRatio += penalty;
             }

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -606,8 +606,6 @@ export class Pitch extends prebase.ProtoM21Object {
      * A# becomes B-flat, D# becomes E-flat, D-flat becomes C#, G# and A-flat are
      * left alone.
      *
-     * AI-assisted (port of music21p Pitch.simplifyEnharmonic).
-     *
      * @example
      * new music21.pitch.Pitch('B#5').simplifyEnharmonic().nameWithOctave;
      * // 'C6'
@@ -652,8 +650,6 @@ export class Pitch extends prebase.ProtoM21Object {
      *
      * music21p does not support accidentals beyond quadruple sharp/flat, so
      * `alterLimit` = 4 is the most you can use.
-     *
-     * AI-assisted (port of music21p Pitch.getAllCommonEnharmonics).
      *
      * @example
      * new music21.pitch.Pitch('c#3').getAllCommonEnharmonics().map(p => p.name);
@@ -1181,10 +1177,9 @@ export class Pitch extends prebase.ProtoM21Object {
 // simplifyMultipleEnharmonics and helpers -- port of music21p pitch module.
 
 /**
- * Cartesian product of a list of pools, iterating the last pool fastest --
- * matching Python's `itertools.product`, so tie-breaking is identical.
- *
- * AI-assisted.
+ * Cartesian product of a list of pools (iterables), iterating the last pool fastest --
+ * like Python's `itertools.product`, so tie-breaking is identical, but not a generator.
+ * Does not support the repeat parameter of itertools.
  */
 function _product<T>(pools: T[][]): T[][] {
     let result: T[][] = [[]];
@@ -1209,7 +1204,7 @@ function _product<T>(pools: T[][]): T[][] {
  * (`accidentalPenalty`), and (3) it shows thirds that can form some triad
  * (`triadAward`).
  *
- * AI-assisted (port of music21p pitch._dissonanceScore).
+ * (keep same as music21p pitch._dissonanceScore).
  */
 function _dissonanceScore(
     pitches: Pitch[],
@@ -1302,8 +1297,6 @@ function _dissonanceScore(
  * Simplify a list of pitches by brute force -- useful if there are fewer than
  * five pitches.  Keeps the first pitch fixed and searches every combination of
  * the common enharmonics of the rest.
- *
- * AI-assisted (port of music21p pitch._bruteForceEnharmonicsSearch).
  */
 function _bruteForceEnharmonicsSearch(
     oldPitches: Pitch[],
@@ -1329,8 +1322,6 @@ function _bruteForceEnharmonicsSearch(
 /**
  * Simplify a list of pitches greedily, left-to-right -- useful for five or more
  * pitches, where brute force would be too slow.
- *
- * AI-assisted (port of music21p pitch._greedyEnharmonicsSearch).
  */
 function _greedyEnharmonicsSearch(
     oldPitches: Pitch[],
@@ -1363,8 +1354,6 @@ function _greedyEnharmonicsSearch(
  * The `keyContext` option supplies a KeySignature or Key used in the
  * simplification.  Note that without a key context we will not simplify
  * everything.
- *
- * AI-assisted (port of music21p pitch.simplifyMultipleEnharmonics).
  *
  * @example
  * music21.pitch.simplifyMultipleEnharmonics([11, 3, 6]).map(p => p.name);

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -1262,6 +1262,10 @@ function _dissonanceScore(
                 // does not accept weird intervals, e.g. with semitones, or
                 // spellings too extreme for m21j to reach (music21p wraps them)
                 const ratio = interval.intervalToPythagoreanRatio(thisInterval);
+                // The constant is 1 / ln(3**12): it normalizes the penalty so a
+                // diminished second (the Pythagorean comma, whose ratio denominator
+                // is 3**12 = 531441) scores exactly 1.0. (music21p carries it as the
+                // bare literal 0.07585326888, formerly 2 * 0.03792663444.)
                 const penalty = Math.log(ratio.denominator) * 0.07585326888;
                 scoreRatio += penalty;
             }

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -11,8 +11,10 @@ import { Music21Exception } from './exceptions21';
 
 import * as prebase from './prebase';
 import * as common from './common';
+import * as interval from './interval';
 
 import type * as clef from './clef';
+import type * as key from './key';
 
 
 interface UpdateAccidentalDisplayParams {
@@ -591,7 +593,125 @@ export class Pitch extends prebase.ProtoM21Object {
     getLowerEnharmonic(inPlace=false) {
         return this._getEnharmonicHelper(inPlace, -1);
     }
-    /* TODO: isEnharmonic, getEnharmonic, getAllCommonEnharmonics */
+
+    /**
+     * Returns a new Pitch (or sets the current one if inPlace is true) that is
+     * either the same as the current pitch or has fewer sharps or flats if
+     * possible.  For instance, E# returns F, while A# remains A# (i.e., does not
+     * take into account that B- is more common than A#).
+     *
+     * If mostCommon is set to true, then the most commonly used enharmonic
+     * spelling is chosen (that is, the one that appears first in key signatures
+     * as you move away from C on the circle of fifths).  Thus, G-flat becomes F#,
+     * A# becomes B-flat, D# becomes E-flat, D-flat becomes C#, G# and A-flat are
+     * left alone.
+     *
+     * AI-assisted (port of music21p Pitch.simplifyEnharmonic).
+     *
+     * @example
+     * new music21.pitch.Pitch('B#5').simplifyEnharmonic().nameWithOctave;
+     * // 'C6'
+     */
+    simplifyEnharmonic({ inPlace=false, mostCommon=false }={}): Pitch {
+        const returnObj = inPlace ? this : this.clone();
+
+        if (returnObj.accidental !== undefined) {
+            if (Math.abs(returnObj.accidental.alter) < 2.0
+                    && !['E#', 'B#', 'C-', 'F-'].includes(returnObj.name)) {
+                // do nothing
+            } else {
+                // by resetting the pitch space value, we get a simpler
+                // enharmonic spelling
+                returnObj.ps = this.ps;
+            }
+        }
+
+        if (mostCommon) {
+            if (returnObj.name === 'D#') {
+                returnObj.step = 'E';
+                returnObj.accidental = new Accidental('flat');
+            } else if (returnObj.name === 'A#') {
+                returnObj.step = 'B';
+                returnObj.accidental = new Accidental('flat');
+            } else if (returnObj.name === 'G-') {
+                returnObj.step = 'F';
+                returnObj.accidental = new Accidental('sharp');
+            } else if (returnObj.name === 'D-') {
+                returnObj.step = 'C';
+                returnObj.accidental = new Accidental('sharp');
+            }
+        }
+
+        return returnObj;
+    }
+
+    /**
+     * Return all common unique enharmonics for a pitch, or those that do not
+     * involve more than `alterLimit` accidentals.  "Higher" enharmonics are
+     * listed before "Lower".
+     *
+     * music21p does not support accidentals beyond quadruple sharp/flat, so
+     * `alterLimit` = 4 is the most you can use.
+     *
+     * AI-assisted (port of music21p Pitch.getAllCommonEnharmonics).
+     *
+     * @example
+     * new music21.pitch.Pitch('c#3').getAllCommonEnharmonics().map(p => p.name);
+     * // ['D-', 'B##']
+     */
+    getAllCommonEnharmonics(alterLimit=2): Pitch[] {
+        const post: Pitch[] = [];
+        const contains = (list: Pitch[], target: Pitch) => list.some(p => p.eq(target));
+
+        const c = this.simplifyEnharmonic({ inPlace: false });
+        if (c.name !== this.name) {
+            post.push(c);
+        }
+        // iterative scan upward
+        let cUp: Pitch = this;
+        while (true) {
+            try {
+                cUp = cUp.getHigherEnharmonic(false);
+            } catch (e) {
+                if (e instanceof Music21Exception) {
+                    break;  // ran out of accidentals
+                }
+                throw e;
+            }
+            if (cUp.accidental !== undefined
+                    && Math.abs(cUp.accidental.alter) > alterLimit) {
+                break;
+            }
+            if (!contains(post, cUp)) {
+                post.push(cUp);
+            } else {  // we are looping
+                break;
+            }
+        }
+        // iterative scan downward
+        let cDown: Pitch = this;
+        while (true) {
+            try {
+                cDown = cDown.getLowerEnharmonic(false);
+            } catch (e) {
+                if (e instanceof Music21Exception) {
+                    break;  // ran out of accidentals
+                }
+                throw e;
+            }
+            if (cDown.accidental !== undefined
+                    && Math.abs(cDown.accidental.alter) > alterLimit) {
+                break;
+            }
+            if (!contains(post, cDown)) {
+                post.push(cDown);
+            } else {  // we are looping
+                break;
+            }
+        }
+        return post;
+    }
+    /* TODO: isEnharmonic, getEnharmonic */
 
     protected _nameInKeySignature(alteredPitches: Pitch[]) : boolean {
         for (const p of alteredPitches) {  // all are altered tones, must have acc
@@ -1055,4 +1175,228 @@ export class Pitch extends prebase.ProtoM21Object {
             = tempPitch.step + accidentalType + '/' + tempPitch.octave;
         return outName;
     }
+}
+
+// -----------------------------------------------------------------------------
+// simplifyMultipleEnharmonics and helpers -- port of music21p pitch module.
+
+/**
+ * Cartesian product of a list of pools, iterating the last pool fastest --
+ * matching Python's `itertools.product`, so tie-breaking is identical.
+ *
+ * AI-assisted.
+ */
+function _product<T>(pools: T[][]): T[][] {
+    let result: T[][] = [[]];
+    for (const pool of pools) {
+        const newResult: T[][] = [];
+        for (const prefix of result) {
+            for (const item of pool) {
+                newResult.push([...prefix, item]);
+            }
+        }
+        result = newResult;
+    }
+    return result;
+}
+
+/**
+ * Calculate the 'dissonance' of a list of pitches based on three criteria.
+ *
+ * A chord is considered more consonant if (1) the numerators and denominators
+ * of the Pythagorean ratios of its constituent intervals are small
+ * (`smallPythagoreanRatio`), (2) it shows few double- or triple-accidentals
+ * (`accidentalPenalty`), and (3) it shows thirds that can form some triad
+ * (`triadAward`).
+ *
+ * AI-assisted (port of music21p pitch._dissonanceScore).
+ */
+function _dissonanceScore(
+    pitches: Pitch[],
+    smallPythagoreanRatio=true,
+    accidentalPenalty=true,
+    triadAward=true
+): number {
+    let scoreAccidentals = 0.0;
+    let scoreRatio = 0.0;
+    let scoreTriad = 0.0;
+
+    if (!pitches.length) {
+        return 0.0;
+    }
+
+    if (accidentalPenalty) {
+        // score_accidentals = accidentals per pitch
+        const accidentals = pitches.map(p => Math.abs(p.accidental?.alter ?? 0));
+        scoreAccidentals = accidentals
+            .map(a => (a > 1 ? a : 0))
+            .reduce((x, y) => x + y, 0) / pitches.length;
+    }
+
+    const intervals: interval.Interval[] = [];
+    if (smallPythagoreanRatio || triadAward) {
+        try {
+            for (let i = 0; i < pitches.length; i++) {
+                for (let j = i + 1; j < pitches.length; j++) {
+                    const p1 = pitches[i];
+                    const p2 = pitches[j].clone();
+                    // music21p sets p2.octave to None here so intervals stay
+                    // simple; m21j pitches always carry an octave, so normalize
+                    // to the default (4) which is music21p's implicit octave.
+                    p2.octave = 4;
+                    intervals.push(new interval.Interval(p1, p2));
+                }
+            }
+        } catch (e) {
+            if (e instanceof interval.IntervalException) {
+                return Infinity;
+            }
+            throw e;
+        }
+    }
+
+    if (smallPythagoreanRatio) {
+        // score_ratio = Pythagorean ratio complexity per pitch
+        try {
+            for (const thisInterval of intervals) {
+                // does not accept weird intervals, e.g. with semitones, or
+                // spellings too extreme for m21j to reach (music21p wraps them)
+                const ratio = interval.intervalToPythagoreanRatio(thisInterval);
+                const penalty = Math.log(ratio.denominator) * 0.07585326888;
+                scoreRatio += penalty;
+            }
+        } catch (e) {
+            if (e instanceof interval.IntervalException) {
+                return Infinity;
+            }
+            throw e;
+        }
+        scoreRatio /= pitches.length;
+    }
+
+    if (triadAward) {
+        // score_triad = number of thirds per pitch (avoid double-base-thirds)
+        for (const thisInterval of intervals) {
+            const simpleDirected = thisInterval.generic.simpleDirected;
+            const intervalSemitones = common.posMod(thisInterval.chromatic.semitones, 12);
+            if (simpleDirected === 3 && (intervalSemitones === 3 || intervalSemitones === 4)) {
+                scoreTriad -= 1.0;
+            } else if (simpleDirected === 6 && (intervalSemitones === 8 || intervalSemitones === 9)) {
+                scoreTriad -= 1.0;
+            }
+        }
+        scoreTriad /= pitches.length;
+    }
+
+    const divisor = Number(smallPythagoreanRatio)
+        + Number(accidentalPenalty) + Number(triadAward);
+    return (scoreAccidentals + scoreRatio + scoreTriad) / divisor;
+}
+
+/**
+ * Simplify a list of pitches by brute force -- useful if there are fewer than
+ * five pitches.  Keeps the first pitch fixed and searches every combination of
+ * the common enharmonics of the rest.
+ *
+ * AI-assisted (port of music21p pitch._bruteForceEnharmonicsSearch).
+ */
+function _bruteForceEnharmonicsSearch(
+    oldPitches: Pitch[],
+    scoreFunc: (pitches: Pitch[]) => number = _dissonanceScore
+): Pitch[] {
+    const fixed = oldPitches.slice(0, 1);
+    const allPossiblePitches = oldPitches.slice(1).map(
+        p => [p, ...p.getAllCommonEnharmonics()]
+    );
+    let best: Pitch[] = fixed.concat(allPossiblePitches.map(pool => pool[0]));
+    let bestScore = Infinity;
+    for (const combo of _product(allPossiblePitches)) {
+        const candidate = fixed.concat(combo);
+        const score = scoreFunc(candidate);
+        if (score < bestScore) {  // strict < keeps the first minimum, as Python min()
+            bestScore = score;
+            best = candidate;
+        }
+    }
+    return best;
+}
+
+/**
+ * Simplify a list of pitches greedily, left-to-right -- useful for five or more
+ * pitches, where brute force would be too slow.
+ *
+ * AI-assisted (port of music21p pitch._greedyEnharmonicsSearch).
+ */
+function _greedyEnharmonicsSearch(
+    oldPitches: Pitch[],
+    scoreFunc: (pitches: Pitch[]) => number = _dissonanceScore
+): Pitch[] {
+    const newPitches = oldPitches.slice(0, 1);
+    for (const oldPitch of oldPitches.slice(1)) {
+        const candidates = [oldPitch, ...oldPitch.getAllCommonEnharmonics()];
+        let best = candidates[0];
+        let bestScore = Infinity;
+        for (const cand of candidates) {
+            const score = scoreFunc([...newPitches, cand]);
+            if (score < bestScore) {
+                bestScore = score;
+                best = cand;
+            }
+        }
+        newPitches.push(best);
+    }
+    return newPitches;
+}
+
+/**
+ * Try to simplify the enharmonic spelling of a list of `Pitch` objects, pitch
+ * name strings, or pitch/pitch-class numbers according to a given criterion.
+ *
+ * A function can be passed as the `criterion` argument; it is minimized in a
+ * greedy, left-to-right fashion.
+ *
+ * The `keyContext` argument supplies a KeySignature or Key used in the
+ * simplification.  Note that without a key context we will not simplify
+ * everything.
+ *
+ * AI-assisted (port of music21p pitch.simplifyMultipleEnharmonics).
+ *
+ * @example
+ * music21.pitch.simplifyMultipleEnharmonics([11, 3, 6]).map(p => p.name);
+ * // ['B', 'D#', 'F#']
+ */
+export function simplifyMultipleEnharmonics(
+    pitches: Iterable<Pitch|string|number>,
+    criterion: (pitches: Pitch[]) => number = _dissonanceScore,
+    keyContext?: key.KeySignature
+): Pitch[] {
+    let oldPitches = Array.from(pitches).map(
+        p => (p instanceof Pitch ? p : new Pitch(p))
+    );
+
+    let removeFirst = false;
+    if (keyContext) {
+        // music21p uses keyContext.asKey('major').tonic; majorName() gives the
+        // same tonic pitch name for this key signature.
+        oldPitches = [new Pitch(keyContext.majorName()), ...oldPitches];
+        removeFirst = true;
+    }
+
+    let simplifiedPitches: Pitch[];
+    if (oldPitches.length < 5) {
+        simplifiedPitches = _bruteForceEnharmonicsSearch(oldPitches, criterion);
+    } else {
+        simplifiedPitches = _greedyEnharmonicsSearch(oldPitches, criterion);
+    }
+
+    // Preserve value of spellingIsInferred
+    for (let i = 0; i < oldPitches.length; i++) {
+        simplifiedPitches[i].spellingIsInferred = oldPitches[i].spellingIsInferred;
+    }
+
+    if (removeFirst) {
+        simplifiedPitches = simplifiedPitches.slice(1);
+    }
+
+    return simplifiedPitches;
 }

--- a/tests/moduleTests/chord.ts
+++ b/tests/moduleTests/chord.ts
@@ -74,6 +74,28 @@ export default function tests() {
         assert.deepEqual(names(withKey), ['D-', 'F', 'A-'], 'C# F G# in A- -> D- F A-');
     });
 
+    test('music21.chord.Chord.simplifyEnharmonics preserves pitch space', assert => {
+        const nwo = (c: music21.chord.Chord) => c.pitches.map(p => p.nameWithOctave);
+        const psOf = (c: music21.chord.Chord) => c.pitches.map(p => p.ps);
+
+        // B#3 -> C4 crosses the octave boundary upward: name and octave change
+        // but the sounding pitch (ps) does not.
+        const up = new music21.chord.Chord('A3 B#3 E4');
+        const upPs = psOf(up);
+        assert.deepEqual(upPs, [57, 60, 64], 'B#3 has ps 60 (same as C4)');
+        up.simplifyEnharmonics(true);
+        assert.deepEqual(nwo(up), ['A3', 'C4', 'E4'], 'A3 B#3 E4 respelled to A3 C4 E4');
+        assert.deepEqual(psOf(up), upPs, 'ps unchanged after respelling B#3 -> C4');
+
+        // C-4 -> B3 crosses the octave boundary downward, ps still preserved.
+        const down = new music21.chord.Chord('G3 C-4 D4');
+        const downPs = psOf(down);
+        assert.deepEqual(downPs, [55, 59, 62], 'C-4 has ps 59 (same as B3)');
+        down.simplifyEnharmonics(true);
+        assert.deepEqual(nwo(down), ['G3', 'B3', 'D4'], 'G3 C-4 D4 respelled to G3 B3 D4');
+        assert.deepEqual(psOf(down), downPs, 'ps unchanged after respelling C-4 -> B3');
+    });
+
     test('music21.chord.Chord.clone deep-copies notes', assert => {
         const c = new music21.chord.Chord('C4 E4 G4');
 

--- a/tests/moduleTests/chord.ts
+++ b/tests/moduleTests/chord.ts
@@ -51,4 +51,26 @@ export default function tests() {
         assert.equal(note1.pitch.nameWithOctave, 'B-4');
         assert.equal(note2.pitch.nameWithOctave, 'B4');
     });
+
+    test('music21.chord.Chord.simplifyEnharmonics', assert => {
+        const names = (c: music21.chord.Chord) => c.pitches.map(p => p.name);
+
+        // The central request: E, A-flat, B is really an E-major triad.
+        const eMajor = new music21.chord.Chord('E A- B');
+        eMajor.simplifyEnharmonics(true);
+        assert.deepEqual(names(eMajor), ['E', 'G#', 'B'], 'E A- B -> E G# B in place');
+
+        // C# F G# is more logical as C# major (C# E# G#).
+        const cSharp = new music21.chord.Chord('C# F G#');
+        const simplified = cSharp.simplifyEnharmonics();
+        assert.deepEqual(names(simplified), ['C#', 'E#', 'G#'], 'C# F G# -> C# E# G#');
+        // not-in-place must leave the original untouched
+        assert.deepEqual(names(cSharp), ['C#', 'F', 'G#'], 'original chord unchanged');
+
+        // keyContext biases the spelling
+        const withKey = new music21.chord.Chord('C# F G#').simplifyEnharmonics(
+            false, new music21.key.Key('A-')
+        );
+        assert.deepEqual(names(withKey), ['D-', 'F', 'A-'], 'C# F G# in A- -> D- F A-');
+    });
 }

--- a/tests/moduleTests/chord.ts
+++ b/tests/moduleTests/chord.ts
@@ -73,4 +73,23 @@ export default function tests() {
         );
         assert.deepEqual(names(withKey), ['D-', 'F', 'A-'], 'C# F G# in A- -> D- F A-');
     });
+
+    test('music21.chord.Chord.clone deep-copies notes', assert => {
+        const c = new music21.chord.Chord('C4 E4 G4');
+
+        const deep = c.clone(true);
+        assert.notStrictEqual(deep.notes[0], c.notes[0], 'deep clone makes new Note objects');
+        assert.notStrictEqual(
+            deep.pitches[0], c.pitches[0], 'deep clone makes new Pitch objects'
+        );
+        deep.notes[1].pitch.name = 'F';  // mutate the clone
+        assert.equal(c.pitches[1].name, 'E', 'mutating a deep clone leaves the original alone');
+
+        // A shallow clone keeps the same Note objects but in a new array.
+        const shallow = c.clone(false);
+        assert.strictEqual(shallow.notes[0], c.notes[0], 'shallow clone shares Note objects');
+        shallow.add(new music21.note.Note('B4'));
+        assert.equal(c.length, 3, 'shallow clone has an independent notes array');
+        assert.equal(shallow.length, 4, 'added note lands only on the shallow clone');
+    });
 }

--- a/tests/moduleTests/chord.ts
+++ b/tests/moduleTests/chord.ts
@@ -114,4 +114,31 @@ export default function tests() {
         assert.equal(c.length, 3, 'shallow clone has an independent notes array');
         assert.equal(shallow.length, 4, 'added note lands only on the shallow clone');
     });
+
+    test('music21.chord.Chord.clone does not share _cache or _overrides', assert => {
+        const c = new music21.chord.Chord('C4 E4 G4');
+        c.root(new music21.pitch.Pitch('E4'));  // sets an override (and caches)
+        c._cache.marker = 1;
+
+        for (const deep of [true, false]) {
+            const cl = c.clone(deep);
+            assert.notStrictEqual(cl._cache, c._cache, `_cache not shared (deep=${deep})`);
+            assert.deepEqual(cl._cache, {}, `clone starts with an empty _cache (deep=${deep})`);
+            assert.notStrictEqual(
+                cl._overrides, c._overrides, `_overrides not shared (deep=${deep})`
+            );
+            assert.equal(cl.root().name, 'E', `root override preserved (deep=${deep})`);
+        }
+
+        // A deep clone also clones music21-object override values.
+        const deepClone = c.clone(true);
+        assert.notStrictEqual(
+            deepClone._overrides.root, c._overrides.root, 'deep clone copies override values'
+        );
+        // Mutating the clone's containers must not touch the original.
+        deepClone._cache.marker = 2;
+        deepClone._overrides.extra = 9;
+        assert.equal(c._cache.marker, 1, 'mutating clone _cache leaves the original intact');
+        assert.notOk(c._overrides.extra, 'mutating clone _overrides leaves the original intact');
+    });
 }

--- a/tests/moduleTests/interval.ts
+++ b/tests/moduleTests/interval.ts
@@ -23,4 +23,26 @@ export default function tests() {
         assert.equal(i.specifier, 1);
         assert.equal(i.specifierAbbreviation, 'P');
     });
+    test('music21.interval.intervalToPythagoreanRatio', assert => {
+        const cases: [string, number, number][] = [
+            ['P4', 4, 3],
+            ['P5', 3, 2],
+            ['M7', 243, 128],
+            ['m23', 2048, 243],
+            ['M3', 81, 64],
+        ];
+        for (const [name, num, den] of cases) {
+            const ratio = interval.intervalToPythagoreanRatio(new Interval(name));
+            assert.equal(ratio.numerator, num, `${name} numerator`);
+            assert.equal(ratio.denominator, den, `${name} denominator`);
+        }
+    });
+    test('music21.interval.convertDiatonicNumberToStep', assert => {
+        // regression: negative diatonic numbers (very low notes) must resolve
+        assert.deepEqual(interval.convertDiatonicNumberToStep(1), ['C', 0]);
+        assert.deepEqual(interval.convertDiatonicNumberToStep(0), ['B', -1]);
+        assert.deepEqual(interval.convertDiatonicNumberToStep(-1), ['A', -1]);
+        assert.deepEqual(interval.convertDiatonicNumberToStep(-4), ['E', -1]);
+        assert.deepEqual(interval.convertDiatonicNumberToStep(-7), ['B', -2]);
+    });
 }

--- a/tests/moduleTests/pitch.ts
+++ b/tests/moduleTests/pitch.ts
@@ -6,6 +6,148 @@ const { test } = QUnit;
 
 export default function tests() {
 
+    const names = (ps: music21.pitch.Pitch[]) => ps.map(p => p.name);
+    const namesWithOctave = (ps: music21.pitch.Pitch[]) => ps.map(p => p.nameWithOctave);
+
+    test('music21.pitch.Pitch.simplifyEnharmonic', assert => {
+        assert.equal(
+            new music21.pitch.Pitch('B#5').simplifyEnharmonic().nameWithOctave, 'C6', 'B#5 simplifies to C6'
+        );
+        // A# stays A# -- fewer accidentals not available
+        assert.equal(
+            new music21.pitch.Pitch('A#2').simplifyEnharmonic().nameWithOctave, 'A#2', 'A#2 stays A#2'
+        );
+        // inPlace returns the same object, mutated
+        const p = new music21.pitch.Pitch('E#3');
+        const returned = p.simplifyEnharmonic({ inPlace: true });
+        assert.equal(p.name, 'F', 'E# simplifies to F in place');
+        assert.strictEqual(returned, p, 'inPlace returns the same Pitch');
+
+        // mostCommon chooses the enharmonic first on the circle of fifths
+        const mostCommon = ['A#4', 'B-4', 'G-4', 'F#4'].map(
+            n => new music21.pitch.Pitch(n).simplifyEnharmonic({ mostCommon: true }).name
+        );
+        assert.deepEqual(mostCommon, ['B-', 'B-', 'F#', 'F#'], 'mostCommon simplifications');
+    });
+
+    test('music21.pitch.Pitch.getAllCommonEnharmonics', assert => {
+        assert.deepEqual(
+            names(new music21.pitch.Pitch('c#3').getAllCommonEnharmonics()),
+            ['D-', 'B##'],
+            'C#3 common enharmonics'
+        );
+        // Higher enharmonics are listed before Lower
+        assert.deepEqual(
+            names(new music21.pitch.Pitch('G4').getAllCommonEnharmonics()),
+            ['A--', 'F##'],
+            'G4 common enharmonics'
+        );
+        // alterLimit caps how many accidentals to allow
+        assert.deepEqual(
+            names(new music21.pitch.Pitch('G-6').getAllCommonEnharmonics(1)),
+            ['F#'],
+            'G-6 with alterLimit 1'
+        );
+        assert.deepEqual(
+            names(new music21.pitch.Pitch('G-6').getAllCommonEnharmonics(3)),
+            ['A---', 'F#', 'E##'],
+            'G-6 with alterLimit 3'
+        );
+    });
+
+    test('music21.pitch.simplifyMultipleEnharmonics', assert => {
+        assert.deepEqual(
+            names(music21.pitch.simplifyMultipleEnharmonics([11, 3, 6])),
+            ['B', 'D#', 'F#'],
+            'pitch classes 11 3 6'
+        );
+        assert.deepEqual(
+            names(music21.pitch.simplifyMultipleEnharmonics([3, 8, 0])),
+            ['E-', 'A-', 'C'],
+            'pitch classes 3 8 0'
+        );
+        assert.deepEqual(
+            namesWithOctave(music21.pitch.simplifyMultipleEnharmonics([
+                new music21.pitch.Pitch('G3'),
+                new music21.pitch.Pitch('C-4'),
+                new music21.pitch.Pitch('D4'),
+            ])),
+            ['G3', 'B3', 'D4'],
+            'G3 C-4 D4 -> G3 B3 D4'
+        );
+        assert.deepEqual(
+            namesWithOctave(music21.pitch.simplifyMultipleEnharmonics([
+                new music21.pitch.Pitch('A3'),
+                new music21.pitch.Pitch('B#3'),
+                new music21.pitch.Pitch('E4'),
+            ])),
+            ['A3', 'C4', 'E4'],
+            'A3 B#3 E4 -> A3 C4 E4'
+        );
+        // The central request: E, A-flat, B simplifies to the E-major triad.
+        assert.deepEqual(
+            names(music21.pitch.simplifyMultipleEnharmonics([
+                new music21.pitch.Pitch('E'),
+                new music21.pitch.Pitch('A-'),
+                new music21.pitch.Pitch('B'),
+            ])),
+            ['E', 'G#', 'B'],
+            'E A- B -> E G# B (E major)'
+        );
+        // Without a key context, extreme spellings are left alone
+        assert.deepEqual(
+            names(music21.pitch.simplifyMultipleEnharmonics([
+                new music21.pitch.Pitch('D--3'),
+                new music21.pitch.Pitch('F-3'),
+                new music21.pitch.Pitch('A--3'),
+            ])),
+            ['D--', 'F-', 'A--'],
+            'no key context leaves extreme spellings'
+        );
+        // The input pitches are not mutated
+        const inputs = [
+            new music21.pitch.Pitch('E'),
+            new music21.pitch.Pitch('A-'),
+            new music21.pitch.Pitch('B'),
+        ];
+        music21.pitch.simplifyMultipleEnharmonics(inputs);
+        assert.deepEqual(names(inputs), ['E', 'A-', 'B'], 'inputs are not mutated');
+    });
+
+    test('music21.pitch.simplifyMultipleEnharmonics keyContext', assert => {
+        assert.deepEqual(
+            names(music21.pitch.simplifyMultipleEnharmonics(
+                [6, 10, 1], undefined, new music21.key.Key('B')
+            )),
+            ['F#', 'A#', 'C#'],
+            'key of B'
+        );
+        assert.deepEqual(
+            names(music21.pitch.simplifyMultipleEnharmonics(
+                [6, 10, 1], undefined, new music21.key.Key('C-')
+            )),
+            ['G-', 'B-', 'D-'],
+            'key of C-'
+        );
+        assert.deepEqual(
+            names(music21.pitch.simplifyMultipleEnharmonics([
+                new music21.pitch.Pitch('D--3'),
+                new music21.pitch.Pitch('F-3'),
+                new music21.pitch.Pitch('A--3'),
+            ], undefined, new music21.key.Key('C'))),
+            ['C', 'E', 'G'],
+            'key of C simplifies D-- F- A-- to C E G'
+        );
+        // compound interval against the (octave-4) tonic does not break spelling
+        assert.deepEqual(
+            namesWithOctave(music21.pitch.simplifyMultipleEnharmonics(
+                [new music21.pitch.Pitch('B5')], undefined, new music21.key.Key('D')
+            )),
+            ['B5'],
+            'B5 in key of D stays B5'
+        );
+    });
+
     test('music21.pitch.Accidental', assert => {
         const a = new music21.pitch.Accidental('-');
         assert.equal(a.alter, -1.0, 'flat alter passed');

--- a/tests/moduleTests/pitch.ts
+++ b/tests/moduleTests/pitch.ts
@@ -117,14 +117,14 @@ export default function tests() {
     test('music21.pitch.simplifyMultipleEnharmonics keyContext', assert => {
         assert.deepEqual(
             names(music21.pitch.simplifyMultipleEnharmonics(
-                [6, 10, 1], undefined, new music21.key.Key('B')
+                [6, 10, 1], { keyContext: new music21.key.Key('B') }
             )),
             ['F#', 'A#', 'C#'],
             'key of B'
         );
         assert.deepEqual(
             names(music21.pitch.simplifyMultipleEnharmonics(
-                [6, 10, 1], undefined, new music21.key.Key('C-')
+                [6, 10, 1], { keyContext: new music21.key.Key('C-') }
             )),
             ['G-', 'B-', 'D-'],
             'key of C-'
@@ -134,14 +134,14 @@ export default function tests() {
                 new music21.pitch.Pitch('D--3'),
                 new music21.pitch.Pitch('F-3'),
                 new music21.pitch.Pitch('A--3'),
-            ], undefined, new music21.key.Key('C'))),
+            ], { keyContext: new music21.key.Key('C') })),
             ['C', 'E', 'G'],
             'key of C simplifies D-- F- A-- to C E G'
         );
         // compound interval against the (octave-4) tonic does not break spelling
         assert.deepEqual(
             namesWithOctave(music21.pitch.simplifyMultipleEnharmonics(
-                [new music21.pitch.Pitch('B5')], undefined, new music21.key.Key('D')
+                [new music21.pitch.Pitch('B5')], { keyContext: new music21.key.Key('D') }
             )),
             ['B5'],
             'B5 in key of D stays B5'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
         // tsc here only typechecks the source and emits .d.ts; it does NOT
         // build the shipped bundle -- Vite/esbuild does (see vite.config.ts),
         // and that is where the browser target lives (baseline-widely-available).
-        // So "esnext" here just lets typecheck accept modern syntax and never
+        // So "esnext" here just lets typecheck accept modern syntax, build fast, and never
         // needs an annual bump; it does not raise the browser floor.
         "target": "esnext",
         // needed in roman.ts _figure

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,9 @@
     "compilerOptions": {
         "allowJs": true,
         "allowSyntheticDefaultImports": true,
+        // lib = the runtime APIs tsc assumes exist. This project does not polyfill.
+        // To match baseline-widely-available, ~30 months,
+        // es20XX should be 3 less than the current year. Change each January.
         "lib": ["dom", "dom.iterable", "es2023"],
         "experimentalDecorators": true,
         "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,14 @@
         "declarationDir": "build",
         "resolveJsonModule": true,
         "esModuleInterop": true,
+        // tsc here only typechecks the source and emits .d.ts; it does NOT
+        // build the shipped bundle -- Vite/esbuild does (see vite.config.ts),
+        // and that is where the browser target lives (baseline-widely-available).
+        // So "esnext" here just lets typecheck accept modern syntax and never
+        // needs an annual bump; it does not raise the browser floor.
         "target": "esnext",
+        // Keep the pre-esnext class-field semantics (esnext would default this
+        // to true, changing class-field emit and flagging existing shadowing).
         "useDefineForClassFields": false,
     },
     "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,7 @@
         // So "esnext" here just lets typecheck accept modern syntax and never
         // needs an annual bump; it does not raise the browser floor.
         "target": "esnext",
-        // Keep the pre-esnext class-field semantics (esnext would default this
-        // to true, changing class-field emit and flagging existing shadowing).
+        // needed in roman.ts _figure
         "useDefineForClassFields": false,
     },
     "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
         "declarationDir": "build",
         "resolveJsonModule": true,
         "esModuleInterop": true,
-        "target": "es6"
+        "target": "esnext",
+        "useDefineForClassFields": false,
     },
     "include": [
         "src/**/*",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,11 +22,10 @@ export default defineConfig({
         sourcemap: true,
         emptyOutDir: true,
 
-        // The shipped bundle's browser floor is set HERE, not in tsconfig.json.
-        // Vite's default build.target is 'baseline-widely-available' (features
-        // in all major browsers for ~30 months), so we leave it unset.
+        // The shipped bundle's browser floor is set here (not tsconfig.json).
+        // This is already Vite's default build.target
+        // ('baseline-widely-available' = features in all major browsers for ~30 months)
         // target: 'baseline-widely-available',
-        // esbuild.target is esnext for speed.
         lib: {
             entry: 'src/main.ts',
             name: 'music21',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,11 @@ export default defineConfig({
         sourcemap: true,
         emptyOutDir: true,
 
-        // this is the default.
+        // The shipped bundle's browser floor is set HERE, not in tsconfig.json.
+        // Vite's default build.target is 'baseline-widely-available' (features
+        // in all major browsers for ~30 months), so we leave it unset. tsconfig
+        // "target" is esnext but only typechecks the source -- it does not build
+        // the bundle and does not affect this floor.
         // target: 'baseline-widely-available',
         // esbuild.target is esnext for speed.
         lib: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,9 +24,7 @@ export default defineConfig({
 
         // The shipped bundle's browser floor is set HERE, not in tsconfig.json.
         // Vite's default build.target is 'baseline-widely-available' (features
-        // in all major browsers for ~30 months), so we leave it unset. tsconfig
-        // "target" is esnext but only typechecks the source -- it does not build
-        // the bundle and does not affect this floor.
+        // in all major browsers for ~30 months), so we leave it unset.
         // target: 'baseline-widely-available',
         // esbuild.target is esnext for speed.
         lib: {


### PR DESCRIPTION
Port `simplifyMultipleEnharmonics` from music21p.  e.g. the chord E–A♭–B simplifies to the E-major triad E–G#–B.

Also ports `Pitch.simplifyEnharmonic`, `Pitch.getAllCommonEnharmonics`, `Chord.simplifyEnharmonics`, and `interval.intervalToPythagoreanRatio` (returns {numerator, denominator} since JS has no Fraction). 

Also included:

* Fix `convertDiatonicNumberToStep` for negative diatonic numbers.
* `Chord.clone(true)` now deep-copies notes; 
* `Chord.clone(false)` clones no longer share _notes/_cache/_overrides.
* `Music21Object.clone()` will always clear `_cache` if it exists.
* Fix tsconfig target to be `esnext` (typecheck-only; Vite owns the browser floor)

AI-assisted (Claude)