### PR TITLE
Avoid multiple slashes on grace note groups

### DIFF
--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -1092,10 +1092,10 @@ export class Renderer {
         graceNotes: note.GeneralNote[],
         options: note.VexflowNoteOptions,
     ): VFGraceNoteGroup {
-        const vfGraces = graceNotes.map(gn => new VFGraceNote({
+        const vfGraces = graceNotes.map((gn, index) => new VFGraceNote({
             keys: gn.vexflowNote(options).getKeys(),
             duration: gn.duration.vexflowDuration,
-            slash: (gn.duration as GraceDuration).slash,
+            slash: index === 0 ? (gn.duration as GraceDuration).slash : false,
         }));
         return new VFGraceNoteGroup(vfGraces, true);
     }

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -1,5 +1,5 @@
 import * as QUnit from 'qunit';
-import type {GraceNoteGroup as VFGraceNoteGroup, TextNote as VFTextNote} from 'vexflow';
+import type {TextNote as VFTextNote} from 'vexflow';
 
 import * as music21 from '../../src/main';
 import type { StreamIterator } from '../../src/stream/iterator';
@@ -277,7 +277,9 @@ export default function tests() {
         const voiceTickables = m.activeVFRenderer.stacks[0].voices[0].getTickables();
         assert.equal(voiceTickables.length, 1);
         const graceNoteGroup = voiceTickables[0].getModifiers()[0];
-        // @ts-ignore
-        assert.equal((graceNoteGroup as VFGraceNoteGroup).grace_notes.length, 2);
+        const graceNotes = (graceNoteGroup as any).grace_notes;
+        assert.equal(graceNotes.length, 2);
+        assert.ok(graceNotes[0].slash);
+        assert.notOk(graceNotes[1].slash);
     });
 }


### PR DESCRIPTION
See post-merge discussion on #319, we can choose to override the `slash=yes` default on display for subsequent notes in a group to prevent multiple slashes:

**Before**
<img width="1772" height="214" alt="image" src="https://github.com/user-attachments/assets/68773a15-6223-4033-99e5-0390155a74ff" />


**After**
<img width="965" height="105" alt="after" src="https://github.com/user-attachments/assets/1c422fb3-382d-4363-a2fd-2b454bc8ac85" />


Sorry, ignore the clef change, and the accidentals, I didn't regenerate the before screenshot 😅 