### PR TITLE
Honor displayType='always' on first pitch too

### DIFF
--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -792,6 +792,20 @@ export class Pitch extends prebase.ProtoM21Object {
             return;
         }
 
+        // here tied and always are treated the same; we assume that
+        // making ties sets the displayStatus, and thus we would not be
+        // overriding that display status here
+        if (cautionaryAll === true
+            || (this.accidental !== undefined
+                && ['even-tied', 'always'].includes(this.accidental.displayType))) {
+            if (this.accidental === undefined) {
+                this.accidental = new Accidental('natural');
+            }
+            // show all accidentals, no matter what is in the past or the key signature
+            this.accidental.displayStatus = true;
+            return;  // do not search past
+        }
+
         // no pitches in past...
         // noinspection PointlessBooleanExpressionJS
         if (pitchPastAll.length === 0) {
@@ -846,21 +860,6 @@ export class Pitch extends prebase.ProtoM21Object {
             }
         }
         // nope, no conflicting accidentals at this name and octave in past...
-
-        // here tied and always are treated the same; we assume that
-        // making ties sets the displayStatus, and thus we would not be
-        // overriding that display status here
-        if (cautionaryAll === true
-            || (this.accidental !== undefined
-                && ['even-tied', 'always'].includes(this.accidental.displayType))) {
-            // show all no matter
-            if (this.accidental === undefined) {
-                this.accidental = new Accidental('natural');
-            }
-            // show all accidentals, even if past encountered
-            this.accidental.displayStatus = true;
-            return;  // do not search past
-        }
 
         // store if a match was found and display set from past pitches
         let setFromPitchPast = false;

--- a/tests/moduleTests/pitch.ts
+++ b/tests/moduleTests/pitch.ts
@@ -501,6 +501,14 @@ export default function tests() {
         n.pitch.updateAccidentalDisplay();
         assert.equal(n.pitch.accidental.displayStatus, true);
 
+        // ... nor may the key signature suppress it
+        const inKey = new music21.note.Note('F#4');
+        inKey.pitch.accidental.displayType = 'always';
+        inKey.pitch.updateAccidentalDisplay(
+            {alteredPitches: new music21.key.Key('G').alteredPitches}
+        );
+        assert.equal(inKey.pitch.accidental.displayStatus, true);
+
         // cautionaryAll adds and shows a natural on an otherwise bare first pitch
         const bare = new music21.note.Note('B4');
         bare.pitch.updateAccidentalDisplay({cautionaryAll: true});

--- a/tests/moduleTests/pitch.ts
+++ b/tests/moduleTests/pitch.ts
@@ -494,6 +494,20 @@ export default function tests() {
         assert.equal(n.pitch.accidental.displayStatus, true);
     });
 
+    test('music21.pitch.updateAccidentalDisplay displayType always with no past', assert => {
+        // an 'always' natural must show even when nothing precedes it: AI-assisted
+        const n = new music21.note.Note('An2');
+        n.pitch.accidental.displayType = 'always';
+        n.pitch.updateAccidentalDisplay();
+        assert.equal(n.pitch.accidental.displayStatus, true);
+
+        // cautionaryAll adds and shows a natural on an otherwise bare first pitch
+        const bare = new music21.note.Note('B4');
+        bare.pitch.updateAccidentalDisplay({cautionaryAll: true});
+        assert.equal(bare.pitch.accidental.name, 'natural');
+        assert.equal(bare.pitch.accidental.displayStatus, true);
+    });
+
     test('music21.pitch.updateAccidentalDisplay respects overrideStatus', assert => {
         const n = new music21.note.Note('Cn');
         n.pitch.accidental.displayStatus = true;

--- a/tests/moduleTests/tinyNotation.ts
+++ b/tests/moduleTests/tinyNotation.ts
@@ -25,4 +25,30 @@ export default function tests() {
         assert.equal(tn('C4\tD4'), 2);
         assert.equal(tn('C4 partBreak D4'), 2);
     });
+
+    test('music21.tinyNotation.TinyNotation explicit naturals show', assert => {
+        // an explicit `n` shows even on the first note of a part: AI-assisted
+        const statuses = (tn: string) => {
+            const s = music21.tinyNotation.TinyNotation(tn)
+                .makeNotation({overrideStatus: true});
+            return Array.from(s.recurse().notes).map(
+                (n: music21.note.Note) => n.pitch.accidental?.displayStatus
+            );
+        };
+
+        assert.deepEqual(statuses('AAn2 Fn'), [true, true]);
+        assert.deepEqual(statuses('4/4 AAn2 Fn'), [true, true]);
+        assert.deepEqual(
+            statuses('AAn2 Fn partBreak Bn Bn'),
+            [true, true, true, true],
+            'naturals show at the start of every part'
+        );
+        assert.deepEqual(statuses('AA2 F'), [undefined, undefined], 'no unasked-for naturals');
+    });
+
+    test('music21.tinyNotation.TinyNotation explicit naturals reach MusicXML', assert => {
+        const p = music21.tinyNotation.TinyNotation('AAn2 Fn');
+        const xml = new music21.musicxml.m21ToXml.GeneralObjectExporter(p).parse();
+        assert.equal(xml.match(/<accidental>natural<\/accidental>/g).length, 2);
+    });
 }


### PR DESCRIPTION
First note in piece/part w/ explicit natural set with displayType='always', like tinyNotation `Cn` was being ignored.  Fixed

updateAccidentalDisplay was short circuiting early if there was no pitchPastAll -- so first note had no way of having its "always" or "even-tied" status read. 

Fixes #325 

AI-Assisted (Claude)