### PR TITLE
Fix TinyNotation and Stream Render problems

### DIFF
--- a/src/duration.ts
+++ b/src/duration.ts
@@ -159,6 +159,12 @@ export class Duration extends prebase.ProtoM21Object {
         if (ql === undefined) {
             ql = 1.0;
         }
+        if (!Number.isFinite(ql)) {
+            throw new Music21Exception(
+                `Duration.quarterLength must be a finite number, not ${ql}`
+            );
+        }
+
         ql = common.opFrac(ql);
         this._quarterLength = ql;
         if (this.linked) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -2021,35 +2021,37 @@ export class Stream<ElementType extends base.Music21Object = base.Music21Object>
         {inPlace=true}: {inPlace?: boolean}={}
     ): vfShow.Renderer {
         const canvasOrSVG = <HTMLDivElement|HTMLCanvasElement> common.coerceHTMLElement(where);
-        const DOMContains = document.querySelector(defaults.appendLocation).contains(canvasOrSVG);
-        if (!DOMContains) {
+        const already_rendered = canvasOrSVG.isConnected;
+        if (!already_rendered) {
             // temporarily add to DOM so Firefox can measure it...
             document.querySelector(defaults.appendLocation).appendChild(canvasOrSVG);
         }
-        const tagName = canvasOrSVG.tagName.toLowerCase();
-        const stream_to_render = inPlace ? this : this.clone(true);
-        stream_to_render.makeNotation({inPlace: true, overrideStatus: true});
-        const vfr = new vfShow.Renderer(stream_to_render, canvasOrSVG);
-        if (tagName === 'canvas') {
-            vfr.rendererType = 'canvas';
-        } else if (tagName === 'svg') {
-            vfr.rendererType = 'svg';
+        try {
+            const tagName = canvasOrSVG.tagName.toLowerCase();
+            const stream_to_render = inPlace ? this : this.clone(true);
+            stream_to_render.makeNotation({inPlace: true, overrideStatus: true});
+            const vfr = new vfShow.Renderer(stream_to_render, canvasOrSVG);
+            if (tagName === 'canvas') {
+                vfr.rendererType = 'canvas';
+            } else if (tagName === 'svg') {
+                vfr.rendererType = 'svg';
+            }
+
+            vfr.render();
+            this.setRenderInteraction(canvasOrSVG);
+            this.activeVFRenderer = vfr;
+            return vfr;
+        } finally {
+            if (!already_rendered) {
+                // Note that this line is one of the two places that in ModuleTests vfShow
+                // is causing the annoying Failed to load resource: net::ERR_FILE_NOT_FOUND
+                // bug in gruntTests -- not sure the other one.  Spent another 90 minutes
+                // diagnosing.  Need to stop for now.
+
+                // remove the adding to DOM so that Firefox could measure it...
+                document.querySelector(defaults.appendLocation).removeChild(canvasOrSVG);
+            }
         }
-
-        vfr.render();
-        this.setRenderInteraction(canvasOrSVG);
-        this.activeVFRenderer = vfr;
-        if (!DOMContains) {
-            // Note that this line is one of the two places that in ModuleTests vfShow
-            // is causing the annoying Failed to load resource: net::ERR_FILE_NOT_FOUND
-            // bug in gruntTests -- not sure the other one.  Spent another 90 minutes
-            // diagnosing.  Need to stop for now.
-
-            // remove the adding to DOM so that Firefox could measure it...
-            document.querySelector(defaults.appendLocation).removeChild(canvasOrSVG);
-        }
-
-        return vfr;
     }
 
     /**

--- a/src/tinyNotation.ts
+++ b/src/tinyNotation.ts
@@ -31,7 +31,7 @@ export const regularExpressions: { [k: string]: RegExp } = {
     SHARP: /^[A-Ga-g]+'*(#+)/,  // simple notation finds
     FLAT: /^[A-Ga-g]+'*(-+)/,  //   double accidentals too
     NAT: /^[A-Ga-g]+'*n/,  // explicit naturals
-    TYPE: /(\d+)/,
+    TYPE: /([1-9]\d*)/,
     TIE: /.~/,  // not preceding ties
     PRECTIE: /~/,  // front ties   // TODO: remove these...
     ID_EL: /=([A-Za-z0-9]*)/,
@@ -216,6 +216,8 @@ export function TinyNotation(textIn: string): stream.Part|stream.Score {
         }
         let MATCH = tnre.TYPE.exec(token);
         if (MATCH) {
+            // Note that the music21p use of 0 to mean full measure with fermata was
+            //   never advertised and is deprecated there, and will not be included here.
             const durationType = parseInt(MATCH[0]);
             noteObj.duration.quarterLength = 4.0 / durationType;
         }

--- a/tests/moduleTests/duration.ts
+++ b/tests/moduleTests/duration.ts
@@ -37,6 +37,14 @@ export default function tests() {
         assert.equal(d.dots, 4, 'got four dots from 7.75');
     });
 
+    test('music21.duration.Duration non-finite quarterLength', assert => {
+        // AI-assisted
+        const d = new music21.duration.Duration(1.0);
+        assert.throws(() => { d.quarterLength = Infinity; }, /finite/, 'Infinity rejected');
+        assert.throws(() => { d.quarterLength = NaN; }, /finite/, 'NaN rejected');
+        assert.equal(d.quarterLength, 1.0, 'quarterLength unchanged after a failed set');
+    });
+
     test('music21.duration.Tuplet', assert => {
         const d = new music21.duration.Duration(0.5);
         const t = new music21.duration.Tuplet(5, 4);

--- a/tests/moduleTests/duration.ts
+++ b/tests/moduleTests/duration.ts
@@ -38,11 +38,10 @@ export default function tests() {
     });
 
     test('music21.duration.Duration non-finite quarterLength', assert => {
-        // AI-assisted
-        const d = new music21.duration.Duration(1.0);
+        const d = new music21.duration.Duration(3.0);
         assert.throws(() => { d.quarterLength = Infinity; }, /finite/, 'Infinity rejected');
         assert.throws(() => { d.quarterLength = NaN; }, /finite/, 'NaN rejected');
-        assert.equal(d.quarterLength, 1.0, 'quarterLength unchanged after a failed set');
+        assert.equal(d.quarterLength, 3.0, 'quarterLength unchanged after a failed set');
     });
 
     test('music21.duration.Tuplet', assert => {

--- a/tests/moduleTests/stream.ts
+++ b/tests/moduleTests/stream.ts
@@ -536,6 +536,37 @@ export default function tests() {
         const div1 = s1.editableAccidentalDOM();
         globalThis.document.querySelector(music21.defaults.appendLocation).appendChild(div1);
     });
+
+    test('music21.stream.Stream renderVexflow unrenderable', assert => {
+        // AI-assisted
+        const appendLocation = globalThis.document.querySelector(
+            music21.defaults.appendLocation
+        );
+        const n = new music21.note.Note('C4');
+        n.pitch.accidental = new music21.pitch.Accidental('triple-sharp');
+        const s = new music21.stream.Measure();
+        s.append(n);
+        const childrenBefore = appendLocation.childElementCount;
+        assert.throws(
+            () => { s.createDOM(); },
+            'Vexflow cannot render a triple sharp'
+        );
+        assert.equal(
+            appendLocation.childElementCount,
+            childrenBefore,
+            'a failed render leaves nothing behind in defaults.appendLocation'
+        );
+
+        const okStream = new music21.stream.Measure();
+        okStream.append(new music21.note.Note('C#4'));
+        okStream.createDOM();
+        assert.equal(
+            appendLocation.childElementCount,
+            childrenBefore,
+            'a successful render also leaves nothing behind'
+        );
+    });
+
     test('music21.stream.Stream makeAccidentals ', assert => {
         const n = new music21.note.Note('G#3');
         const n2 = new music21.note.Note('G#3');

--- a/tests/moduleTests/tinyNotation.ts
+++ b/tests/moduleTests/tinyNotation.ts
@@ -26,6 +26,13 @@ export default function tests() {
         assert.equal(tn('C4 partBreak D4'), 2);
     });
 
+    test('music21.tinyNotation.TinyNotation zero duration type', assert => {
+        // 0 is not a duration type in m21j, so it is ignored: AI-assisted
+        const s = music21.tinyNotation.TinyNotation('c0 d4');
+        const qls = Array.from(s.recurse().notes).map(n => n.duration.quarterLength);
+        assert.deepEqual(qls, [1.0, 1.0]);
+    });
+
     test('music21.tinyNotation.TinyNotation explicit naturals show', assert => {
         // an explicit `n` shows even on the first note of a part: AI-assisted
         const statuses = (tn: string) => {

--- a/tests/moduleTests/tinyNotation.ts
+++ b/tests/moduleTests/tinyNotation.ts
@@ -27,10 +27,10 @@ export default function tests() {
     });
 
     test('music21.tinyNotation.TinyNotation zero duration type', assert => {
-        // 0 is not a duration type in m21j, so it is ignored: AI-assisted
-        const s = music21.tinyNotation.TinyNotation('c0 d4');
+        // 0 is not a duration type in m21j, so it is ignored
+        const s = music21.tinyNotation.TinyNotation('e2 c0 d4');
         const qls = Array.from(s.recurse().notes).map(n => n.duration.quarterLength);
-        assert.deepEqual(qls, [1.0, 1.0]);
+        assert.deepEqual(qls, [2.0, 2.0, 1.0]);
     });
 
     test('music21.tinyNotation.TinyNotation explicit naturals show', assert => {

--- a/tests/run_qunit_playwright.ts
+++ b/tests/run_qunit_playwright.ts
@@ -13,7 +13,9 @@ async function main(): Promise<void> {
 
     page.on('console', msg => {
         const type = msg.type();   // 'log', 'error', 'warning', etc.
-        console[type](`[browser:${type}]`, msg.text());
+        // Chromium's names for these do not all match Node's console methods.
+        const logFn = console[type] ?? (type === 'warning' ? console.warn : console.log);
+        logFn(`[browser:${type}]`, msg.text());
     });
 
     // Allow narrowing via env vars for quick debugging:


### PR DESCRIPTION
1. A tinynotation of 'c0' would make an infinite duration note and hang the browser (when trying to divide it into whole notes or something to render).  0 is now ignored.
2. No duration.quarterLength = inf is allowed.  Zero is fine.  not inf.
3. When measuring stream width, those that do not render properly are removed from the DOM just like those that succeed.  Ends the whole pile of broken streams at the end of the sandbox problem.
4. Fix a QUnit test "harness" for console.warn (not console.warning).

Human written (w/ AI advice), AI-Tested