### PR TITLE
Render a bare Measure that contains Voices

### DIFF
--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -213,7 +213,9 @@ export class Renderer {
         let isPartlike = false;
         const isFlat = s.isFlat;
 
-        if (s.isClassOrSubclass('Score')) {
+        if (s.isClassOrSubclass('Measure')) {
+            // a Measure is never score- or part-like, even holding Voices.
+        } else if (s.isClassOrSubclass('Score')) {
             isScorelike = true;
         } else if (s.isClassOrSubclass('Part')) {
             // might be a Part with measures and voices.

--- a/src/vfShow.ts
+++ b/src/vfShow.ts
@@ -211,29 +211,28 @@ export class Renderer {
 
         let isScorelike = false;
         let isPartlike = false;
-        const isFlat = s.isFlat;
+        let isMeasurelike = false;
 
-        if (s.isClassOrSubclass('Measure')) {
-            // a Measure is never score- or part-like, even holding Voices.
+        if (s.isFlat || s.isClassOrSubclass('Measure')) {
+            // a Measure stays measure-like even when it holds Voices.
+            isMeasurelike = true;
         } else if (s.isClassOrSubclass('Score')) {
             isScorelike = true;
         } else if (s.isClassOrSubclass('Part')) {
             // might be a Part with measures and voices.
             isPartlike = true;
-        } else if (!isFlat && !(s.get(0) as stream.Stream).isFlat) {
+        } else if (!(s.get(0) as stream.Stream).isFlat) {
             isScorelike = true;
-        } else if (!isFlat) {
+        } else {
             isPartlike = true;
         }
         // requires organization Score -> Part -> Measure -> elements...
-        if (isFlat) {
-            this.prepareArrivedFlat(s);
-        } else if (isScorelike) {
+        if (isScorelike) {
             this.prepareScorelike(s as stream.Score);
         } else if (isPartlike) {
             this.preparePartlike(s as stream.Part, {multipart: false});
-        } else {
-            this.prepareArrivedFlat(s);
+        } else if (isMeasurelike) {
+            this.prepareArrivedMeasurelike(s);
         }
         this.formatMeasureStacks();
         this.drawTies();
@@ -291,12 +290,11 @@ export class Renderer {
 
     /**
      *
-     * Prepares a score that arrived flat... sets up
-     * stacks and vfTies after calling prepareFlat
-     *
-     * @param {Stream} m - a flat stream (maybe a measure or voice)
+     * Prepares a stream that arrives here as a single measure's worth of music
+     * -- a Measure (with or without Voices) or any flat stream -- setting up
+     * stacks and vfTies after calling prepareMeasure.
      */
-    prepareArrivedFlat(m: stream.Stream): void {
+    prepareArrivedMeasurelike(m: stream.Stream): void {
         const stack = new RenderStack();
         m.renderOptions.leftBarline = 'none';
         this.prepareMeasure(m as stream.Measure, stack);
@@ -470,7 +468,7 @@ export class Renderer {
         // Retrieve loose notes in `p` (flat)
         p_recursed.push(...Array.from(p.notesAndRests));
         // Other stream nesting patterns not supported
-        // prepareTies currently called by prepareArrivedFlat() and preparePartlike()
+        // prepareTies currently called by prepareArrivedMeasurelike() and preparePartlike()
         // supposes well-formed
         for (let i = 0; i < p_recursed.length - 1; i++) {
             const thisNote = p_recursed[i];

--- a/tests/moduleTests/testHelpers.ts
+++ b/tests/moduleTests/testHelpers.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared helpers for tests that check what actually reached the screen.
+ * AI-assisted.
+ */
+
+/**
+ * Noteheads drawn inside `where` -- an element returned by appendNewDOM(),
+ * createDOM(), and friends.
+ */
+export function renderedNoteheads(where: HTMLElement): Element[] {
+    return Array.from(where.querySelectorAll('svg .vf-notehead'));
+}
+
+/**
+ * Did `where` get a stave with at least one note drawn on it?
+ *
+ * An empty stream still draws a stave and a clef, so the noteheads are what
+ * separate real music from an empty system.
+ */
+export function wasMusicRendered(where: HTMLElement): boolean {
+    return (
+        where.querySelector('svg .vf-stave') !== null
+        && renderedNoteheads(where).length > 0
+    );
+}

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -81,6 +81,26 @@ export default function tests() {
         assert.deepEqual(renderer.vfTies[0].notes.last_note, n2.activeVexflowNote);
     });
 
+    test('music21.vfShow.Renderer Measure with Voices and no Part', assert => {
+        const m = new music21.stream.Measure();
+        m.append(new music21.meter.TimeSignature('2/4'));
+        for (const pitch_name of ['C#4', 'C4']) {
+            const v = new music21.stream.Voice();
+            const n = new music21.note.Note(pitch_name);
+            n.duration.type = 'half';
+            v.append(n);
+            m.insert(0, v);
+        }
+        m.appendNewDOM();
+
+        const stacks = m.activeVFRenderer.stacks;
+        assert.equal(stacks.length, 1, 'one stack for the measure');
+        assert.equal(stacks[0].voices.length, 2, 'both voices reached the renderer');
+        for (const vf_voice of stacks[0].voices) {
+            assert.equal(vf_voice.getTickables().length, 1, 'voice has its note');
+        }
+    });
+
     test('music21.vfShow.Renderer prepareTies in voices across barline', assert => {
         const m1_sop_voice = new music21.stream.Voice();
         m1_sop_voice.id = 'Soprano';

--- a/tests/moduleTests/vfShow.ts
+++ b/tests/moduleTests/vfShow.ts
@@ -3,6 +3,7 @@ import type {TextNote as VFTextNote} from 'vexflow';
 
 import * as music21 from '../../src/main';
 import type { StreamIterator } from '../../src/stream/iterator';
+import { renderedNoteheads, wasMusicRendered } from './testHelpers';
 
 const { test } = QUnit;
 
@@ -91,7 +92,9 @@ export default function tests() {
             v.append(n);
             m.insert(0, v);
         }
-        m.appendNewDOM();
+        const where = m.appendNewDOM();
+        assert.ok(wasMusicRendered(where), 'music reached the svg');
+        assert.equal(renderedNoteheads(where).length, 2, 'a notehead for each voice');
 
         const stacks = m.activeVFRenderer.stacks;
         assert.equal(stacks.length, 1, 'one stack for the measure');


### PR DESCRIPTION
This example with two voices should have drawn two half notes in 2/4, but drew an empty SVG:

```js
const s = new music21.stream.Measure();

const n = new music21.note.Note("C#4");
n.duration.type = "half";
const v1 = new music21.stream.Voice()
v1.append(n);

const n2 = new music21.note.Note("C4");
n2.duration.type = "half";
const v2 = new music21.stream.Voice()
v2.append(n2);

s.append(new music21.meter.TimeSignature('2/4'));
s.insert(0, v1);
s.insert(0, v2);

s.replaceDOM('#mainSVG');
```

Wrapping the Measure in a Part made it the problem go away (that is the music appeared), so the notes and voices were fine -- the Measure alone was the problem.

## Why

`Renderer.render()` decides what kind of rendering to do by asking whether the
stream is flat and whether its first element is flat. It was taking a shortcut and assuming
a Measure was flat(!). A Measure holding Voices
is not flat, is neither a Score nor a Part, and its first element -- a Voice --
is flat. So it landed in the part-like branch. `preparePartlike()` then asked
the stream for its measures; a Measure contains none, the loop ran zero times,
and `prepareMeasure()` -- which draws voices perfectly well -- was never
called. Hence a stave-less, note-less SVG.

## Fix

Check for Measure first and let it fall through to `prepareArrivedFlat()`,
which calls `prepareMeasure()`. Two lines in `src/vfShow.ts`, plus a test in
`tests/moduleTests/vfShow.ts` that renders the snippet above and asserts both
voices reach the renderer with their notes.

Then Myke got involved and said, "Wait?  Why does a Measure with voices go to `prepareArrivedFlat()`? That's a bad name for it" -- so now that routine is called `prepareArrivedMeasurelike" -- for any Measure object or show on a flat stream.Stream object. 

AI-Assisted (Claude)
