### PR TITLE
music21j v0.23.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ A complete page is in `testHTML/sfElsewhereCDN.html`.
 
 ## Version
 
-0.23.6 (beta)
+0.23.7 (beta)
 
 ## License
 
@@ -380,6 +380,7 @@ from .gitignore) which allows it to serve from its own sound files.
 
 Just documenting major changes at different versions, starting with 0.20
 
+* v0.23.7 -- Lone Measure with Voices renders; replaceDOM by id repeatable; one grace-group slash.
 * v0.23.6 -- Tinynotation errors, inf. quarterLength catch, zombie streams don't litter page.
 * v0.23.4 -- Allow first note of Stream to export with natural show.
 * v0.23.3 -- Update midicube to 0.10.3 to fix legato error.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music21j",
-  "version": "0.23.6",
+  "version": "0.23.7",
   "description": "A toolkit for computer-aided musicology, JavaScript version",
 
   "_main_etc": "these are the legacy urls; exports:. is the modern standard",

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,7 +84,7 @@ import * as webmidi from './webmidi';
 
 import { debug } from './debug';
 
-export const VERSION = '0.23.6';
+export const VERSION = '0.23.7';
 
 export {
     MIDI,


### PR DESCRIPTION
Version bump and changelog for v0.23.7, covering the three PRs merged since
v0.23.6:

* #323 -- only the first note of a grace group gets a slash
* #330 -- `replaceDOM('#someId')` can be called more than once
* #332 -- a Measure holding Voices renders on its own, not just inside a Part

Bumped in `package.json`, `src/main.ts` (`VERSION`), and the README's Version
section; changelog line added to the README.  `package.json` was edited by hand
rather than with `npm version`, to keep its blank-line grouping.

Typecheck, lint, and 1281 tests pass locally.

Merge this before publishing -- `npm publish` and the `v0.23.7` tag still need
to be run by a human with npm credentials.

AI-Assisted (Claude)
