### PR TITLE
Fix unicode accidentals for weird ones

### DIFF
--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -137,7 +137,7 @@ export class Accidental extends prebase.ProtoM21Object {
             this._name = 'triple-sharp';
             this._alter = 3.0;
             this._modifier = '###';
-            this._unicodeModifier = '&#x1d12a;';
+            this._unicodeModifier = '♯&#x1d12a;';
         } else if (
             accName === 'quadruple-flat'
             || accName === '----'
@@ -146,7 +146,7 @@ export class Accidental extends prebase.ProtoM21Object {
             this._name = 'quadruple-flat';
             this._alter = -4.0;
             this._modifier = '----';
-            this._unicodeModifier = '♭&#x1d12b;';
+            this._unicodeModifier = '&#x1d12b;&#x1d12b;';
         } else if (
             accName === 'quadruple-sharp'
             || accName === '####'
@@ -155,7 +155,7 @@ export class Accidental extends prebase.ProtoM21Object {
             this._name = 'quadruple-sharp';
             this._alter = 4.0;
             this._modifier = '####';
-            this._unicodeModifier = '&#x1d12a;';
+            this._unicodeModifier = '&#x1d12a;&#x1d12a;';
         } else {
             throw new Music21Exception('Accidental is not supported: ' + accName);
         }
@@ -236,8 +236,8 @@ export class Accidental extends prebase.ProtoM21Object {
     }
 
     /**
-     * Returns the modifier in unicode or
-     * for double and triple accidentals, as a hex escape
+     * Returns the modifier in unicode or, for the double and higher
+     * accidentals, as a hex escape.  Each accidental has its own spelling.
      *
      * @type {string}
      * @readonly

--- a/tests/moduleTests/pitch.ts
+++ b/tests/moduleTests/pitch.ts
@@ -161,6 +161,26 @@ export default function tests() {
         assert.equal(b.name, 'flat', 'flat name passed');
     });
 
+    test('music21.pitch.Accidental unicode distinguishes every accidental', assert => {
+        // Each accidental gets its own unicode spelling, and the flat side
+        // mirrors the sharp side.  Port of music21p #2021.
+        const names = [
+            'quadruple-flat', 'triple-flat', 'double-flat', 'flat', 'natural',
+            'sharp', 'double-sharp', 'triple-sharp', 'quadruple-sharp',
+        ];
+        const spellings = names.map(n => new music21.pitch.Accidental(n).unicodeModifier);
+        assert.equal(new Set(spellings).size, names.length, 'all spellings differ');
+
+        // three sharps is a sharp plus a double sharp; four is two double sharps
+        assert.equal(new music21.pitch.Accidental('###').unicodeModifier, '♯&#x1d12a;');
+        assert.equal(new music21.pitch.Accidental('####').unicodeModifier, '&#x1d12a;&#x1d12a;');
+        // and the flat side mirrors it
+        assert.equal(new music21.pitch.Accidental('---').unicodeModifier, '♭&#x1d12b;');
+        assert.equal(new music21.pitch.Accidental('----').unicodeModifier, '&#x1d12b;&#x1d12b;');
+
+        assert.equal(new music21.pitch.Pitch('C###4').unicodeName, 'C♯&#x1d12a;');
+    });
+
     test('music21.pitch.Pitch', assert => {
         const p = new music21.pitch.Pitch('D#5');
         assert.equal(p.name, 'D#', 'Pitch Name set to D#');


### PR DESCRIPTION
Port of music21 PR #2021 -- fixes triple-sharp, quadruple-sharp and quadruple flat.  

m21j has no quarter tones, so the half-flat half of #2021 does not apply.

AI-assisted (Claude)