### PR TITLE
Add support for implicit octaves

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,5 +1,7 @@
 export const defaults = {
     appendLocation: 'body',
+    // octave reported by a Pitch that was never given one; see Pitch.octaveIsImplicit
+    pitchOctave: 4,
 };
 
 export default defaults;

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -289,6 +289,7 @@ export class GenericInterval extends prebase.ProtoM21Object {
      * Transpose a pitch by this generic interval, maintaining accidentals
      */
     transposePitch(p: pitch.Pitch): pitch.Pitch {
+        const useImplicitOctave = p.octaveIsImplicit;
         const pitch2 = new pitch.Pitch();
         pitch2.step = p.step;
         pitch2.octave = p.octave;
@@ -306,6 +307,9 @@ export class GenericInterval extends prebase.ProtoM21Object {
         pitch2.octave = newOctave;
         if (p.accidental !== undefined) {
             pitch2.accidental = new pitch.Accidental(p.accidental.name);
+        }
+        if (useImplicitOctave) {
+            pitch2.octaveIsImplicit = true;
         }
         return pitch2;
     }
@@ -734,16 +738,12 @@ export class ChromaticInterval extends prebase.ProtoM21Object {
      * Transposes pitches but does not maintain accidentals, etc.
      */
     transposePitch(p: pitch.Pitch): pitch.Pitch {
-        let useImplicitOctave = false;
-        if (p.octave === undefined) {
-            // not yet implemented in m21j
-            useImplicitOctave = true;
-        }
+        const useImplicitOctave = p.octaveIsImplicit;
         const pps = p.ps;
         const newPitch = new pitch.Pitch();
         newPitch.ps = pps + this.semitones;
         if (useImplicitOctave) {
-            newPitch.octave = undefined;
+            newPitch.octaveIsImplicit = true;
         }
         return newPitch;
     }
@@ -949,13 +949,15 @@ export class Interval extends prebase.ProtoM21Object {
         p: pitch.Pitch,
         { reverse=false, maxAccidental=4 }={}
     ): pitch.Pitch {
-        /*
-        var useImplicitOctave = false;
-        if (p.octave === undefined) {
-            useImplicitOctave = true;
+        // transpose with a real octave, then forget it again, as music21p does:
+        // the generic interval alone cannot span more than an octave otherwise.
+        const useImplicitOctave = p.octaveIsImplicit;
+        let pitch1 = p;
+        if (useImplicitOctave) {
+            pitch1 = p.clone();
+            pitch1.octaveIsImplicit = false;
         }
-         */
-        const pitch2 = this.diatonic.generic.transposePitch(p);
+        const pitch2 = this.diatonic.generic.transposePitch(pitch1);
         pitch2.accidental = undefined;
         // step and octave are right now, but not necessarily accidental
         let halfStepsToFix: number;
@@ -976,6 +978,9 @@ export class Interval extends prebase.ProtoM21Object {
                 'Interval.transposePitch -- fixing half steps for '
                     + halfStepsToFix
             );
+        }
+        if (useImplicitOctave) {
+            pitch2.octaveIsImplicit = true;
         }
         return pitch2;
     }

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -289,7 +289,6 @@ export class GenericInterval extends prebase.ProtoM21Object {
      * Transpose a pitch by this generic interval, maintaining accidentals
      */
     transposePitch(p: pitch.Pitch): pitch.Pitch {
-        const useImplicitOctave = p.octaveIsImplicit;
         const pitch2 = new pitch.Pitch();
         pitch2.step = p.step;
         pitch2.octave = p.octave;
@@ -308,7 +307,7 @@ export class GenericInterval extends prebase.ProtoM21Object {
         if (p.accidental !== undefined) {
             pitch2.accidental = new pitch.Accidental(p.accidental.name);
         }
-        if (useImplicitOctave) {
+        if (p.octaveIsImplicit) {
             pitch2.octaveIsImplicit = true;
         }
         return pitch2;
@@ -738,11 +737,10 @@ export class ChromaticInterval extends prebase.ProtoM21Object {
      * Transposes pitches but does not maintain accidentals, etc.
      */
     transposePitch(p: pitch.Pitch): pitch.Pitch {
-        const useImplicitOctave = p.octaveIsImplicit;
         const pps = p.ps;
         const newPitch = new pitch.Pitch();
         newPitch.ps = pps + this.semitones;
-        if (useImplicitOctave) {
+        if (p.octaveIsImplicit) {
             newPitch.octaveIsImplicit = true;
         }
         return newPitch;
@@ -951,9 +949,8 @@ export class Interval extends prebase.ProtoM21Object {
     ): pitch.Pitch {
         // transpose with a real octave, then forget it again, as music21p does:
         // the generic interval alone cannot span more than an octave otherwise.
-        const useImplicitOctave = p.octaveIsImplicit;
         let pitch1 = p;
-        if (useImplicitOctave) {
+        if (p.octaveIsImplicit) {
             pitch1 = p.clone();
             pitch1.octaveIsImplicit = false;
         }
@@ -979,7 +976,7 @@ export class Interval extends prebase.ProtoM21Object {
                     + halfStepsToFix
             );
         }
-        if (useImplicitOctave) {
+        if (p.octaveIsImplicit) {
             pitch2.octaveIsImplicit = true;
         }
         return pitch2;

--- a/src/key.ts
+++ b/src/key.ts
@@ -141,7 +141,9 @@ export class KeySignature extends base.Music21Object {
         for (let i = 0; i < Math.abs(this.sharps); i++) {
             pKeep = transInterval.transposePitch(pKeep);
             pKeep.octave = 4;
-            post.push(pKeep);
+            const p = pKeep.clone();
+            p.octaveIsImplicit = true;
+            post.push(p);
         }
         this._alteredPitchesCache = post;
         return post;
@@ -244,7 +246,9 @@ export class KeySignature extends base.Music21Object {
         for (let i = 0; i < transTimes; i++) {
             newPitch = transInterval.transposePitch(newPitch);
         }
-        newPitch.octave = originalOctave;
+        if (!p.octaveIsImplicit) {
+            newPitch.octave = originalOctave;
+        }
         return newPitch;
     }
 }

--- a/src/key.ts
+++ b/src/key.ts
@@ -140,10 +140,10 @@ export class KeySignature extends base.Music21Object {
         let pKeep = new pitch.Pitch(startPitch);
         for (let i = 0; i < Math.abs(this.sharps); i++) {
             pKeep = transInterval.transposePitch(pKeep);
-            pKeep.octave = 4;
-            const p = pKeep.clone();
-            p.octaveIsImplicit = true;
-            post.push(p);
+            // an implicit octave reports 4, which is the anchor the next
+            // transposition needs, so no separate explicit copy is required
+            pKeep.octaveIsImplicit = true;
+            post.push(pKeep);
         }
         this._alteredPitchesCache = post;
         return post;

--- a/src/musicxml/m21ToXml.ts
+++ b/src/musicxml/m21ToXml.ts
@@ -846,7 +846,7 @@ export class MeasureExporter extends XMLExporterBase {
             const mxAlter = this.subElement(mxPitch, 'alter');
             mxAlter.innerHTML = common.numToIntOrFloat(p.accidental.alter).toString();
         }
-        this._setTagTextFromAttribute(p, mxPitch, 'octave', 'implicitOctave');
+        this._setTagTextFromAttribute(p, mxPitch, 'octave');
         return mxPitch;
     }
     // TODO(msc): fretNoteToXml

--- a/src/note.ts
+++ b/src/note.ts
@@ -701,7 +701,7 @@ export class Note extends NotRest {
         return this.pitch.octave;
     }
 
-    set octave(nn: number|undefined) {
+    set octave(nn: number) {
         this.pitch.octave = nn;
     }
 

--- a/src/note.ts
+++ b/src/note.ts
@@ -693,11 +693,15 @@ export class Note extends NotRest {
         this.pitch.step = nn;
     }
 
+    /**
+     * The octave of this Note's Pitch; always a number.  See
+     * {@link music21.pitch.Pitch#octaveIsImplicit} for whether one was ever given.
+     */
     get octave(): number {
         return this.pitch.octave;
     }
 
-    set octave(nn: number) {
+    set octave(nn: number|undefined) {
         this.pitch.octave = nn;
     }
 

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -400,16 +400,15 @@ export class Pitch extends prebase.ProtoM21Object {
      * The octave of the Pitch, where middle C = C4 and octaves change between
      * B and C.  Always a number: a Pitch created without an octave reports the
      * default octave, `defaults.pitchOctave` (4), and has
-     * {@link Pitch#octaveIsImplicit} true.  Setting it makes the octave explicit.
-     *
-     * Setting `.octave = undefined` is deprecated; set `.octaveIsImplicit = true`.
+     * {@link Pitch#octaveIsImplicit} true.  Setting it makes the octave explicit;
+     * to make a Pitch octaveless, set `.octaveIsImplicit = true`.
      */
     get octave(): number {
         return this._octave ?? defaults.pitchOctave;
     }
 
-    set octave(o: number|undefined) {
-        this._octave = (o === undefined || o === null) ? undefined : o;
+    set octave(o: number) {
+        this._octave = o;
     }
 
     /**

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -584,7 +584,6 @@ export class Pitch extends prebase.ProtoM21Object {
     _getEnharmonicHelper(inPlace=false, directionInt=0) {
         // differs from Python version because
         // cannot import interval here.
-        const octaveWasImplicit = this.octaveIsImplicit;
         const p = this.clone();
         p.diatonicNoteNum += directionInt;
         if (p.accidental === undefined) {
@@ -597,7 +596,7 @@ export class Pitch extends prebase.ProtoM21Object {
         }
 
         if (!inPlace) {
-            if (octaveWasImplicit) {
+            if (this.octaveIsImplicit) {
                 p.octaveIsImplicit = true;
             }
             return p;
@@ -607,9 +606,7 @@ export class Pitch extends prebase.ProtoM21Object {
         if (p.microtone === undefined) {
             this.microtone = p.microtone;
         }
-        if (octaveWasImplicit) {
-            this.octaveIsImplicit = true;
-        } else {
+        if (!this.octaveIsImplicit) {  // step and accidental do not touch the octave
             this.octave = p.octave;
         }
         return p;
@@ -659,6 +656,8 @@ export class Pitch extends prebase.ProtoM21Object {
             } else {
                 // by resetting the pitch space value, we get a simpler
                 // enharmonic spelling
+                // read first: setting .ps gives returnObj -- which is `this`
+                // when inPlace -- an explicit octave
                 const octaveWasImplicit = this.octaveIsImplicit;
                 returnObj.ps = this.ps;
                 if (octaveWasImplicit) {

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -11,6 +11,7 @@ import { Music21Exception } from './exceptions21';
 
 import * as prebase from './prebase';
 import * as common from './common';
+import defaults from './defaults';
 import * as interval from './interval';
 
 import type * as clef from './clef';
@@ -300,8 +301,10 @@ export const midiToName = [
  * - Octave may be specified after the name + accidental: "C#4" etc.
  * - Octave can be arbitrarily high ("C10") but only as low as "C0" because
  *     "C-1" would be interpreted as C-flat octave 1; shift octave later for very low notes.
- * - If octave is not specified, the system will usually use octave 4, but might
- *     adjust according to context. If you do not like this behavior, give an octave always.
+ * - If octave is not specified, the pitch stands for any octave: its `.octave`
+ *     reports the default octave (4) and `.octaveIsImplicit` is true.  Code that
+ *     builds scales, chords, etc. may fix an octave according to context.  If you
+ *     do not like this behavior, give an octave always.
  * - Microtones are not supported in music21j (they are in music21p)
  *
  * @param {string|number} pn - name of the pitch, with or without octave, see above.
@@ -315,7 +318,8 @@ export const midiToName = [
  * @property {string} nameWithOctave - letter name of pitch + accidental
  *     modifier + octave; changes automatically w/ step, accidental, and octave
  * @property {number} octave - number for the octave, where middle C = C4, and
- *     octaves change between B and C; default 4
+ *     octaves change between B and C; always a number, 4 if never set
+ * @property {boolean} octaveIsImplicit - true if no octave was ever given
  * @property {number} ps - pitch space number, like midi number but floating
  *     point and w/ no restriction on range. C4 = 60.0
  * @property {string} step - letter name for the pitch (C-G, A, B),
@@ -324,7 +328,8 @@ export const midiToName = [
 export class Pitch extends prebase.ProtoM21Object {
     static get className() { return 'music21.pitch.Pitch'; }
     protected _step: string = 'C';
-    protected _octave: number = 4;
+    // undefined means implicit: .octave then reports defaults.pitchOctave
+    protected _octave: number|undefined;
     protected _accidental: Accidental|undefined;
     spellingIsInferred: boolean = false;
     microtone = undefined;
@@ -335,9 +340,12 @@ export class Pitch extends prebase.ProtoM21Object {
         /* pn can be a nameWithOctave */
         if (typeof pn === 'number') {
             if (pn < 12) {
-                pn += 60; // pitchClass
+                // a pitchClass implies no octave
+                this.ps = pn + 60;
+                this.octaveIsImplicit = true;
+            } else {
+                this.ps = pn;
             }
-            this.ps = pn;
         } else if (pn.match(/\d+/)) {
             this.nameWithOctave = pn;
         } else {
@@ -356,7 +364,7 @@ export class Pitch extends prebase.ProtoM21Object {
         if (!other.isClassOrSubclass('Pitch')) {
             return false;
         }
-        if (this.octave === other.octave
+        if (this._octave === other._octave
             && this.step === other.step
             && (!(this.accidental && other.accidental)
                 || (this.accidental.eq(other.accidental)))
@@ -388,21 +396,49 @@ export class Pitch extends prebase.ProtoM21Object {
         this.spellingIsInferred = false;
     }
 
+    /**
+     * The octave of the Pitch, where middle C = C4 and octaves change between
+     * B and C.  Always a number: a Pitch created without an octave reports the
+     * default octave, `defaults.pitchOctave` (4), and has
+     * {@link Pitch#octaveIsImplicit} true.  Setting it makes the octave explicit.
+     *
+     * Setting `.octave = undefined` is deprecated; set `.octaveIsImplicit = true`.
+     */
     get octave(): number {
-        return this._octave;
+        return this._octave ?? defaults.pitchOctave;
     }
 
-    set octave(o: number) {
-        this._octave = o;
+    set octave(o: number|undefined) {
+        this._octave = (o === undefined || o === null) ? undefined : o;
     }
 
-    get implicitOctave(): number {
-        const o = this._octave;
-        if (o === undefined) {
-            return 4; // TODO(msc): get from defaults.
-        } else {
-            return o;
+    /**
+     * True if this Pitch was never given an octave, so it stands for its pitch
+     * class in any octave: {@link Pitch#nameWithOctave} prints without an octave
+     * number and {@link Pitch#octave} reports the default, 4.
+     *
+     * Setting it to true makes the pitch octaveless again; setting it to false
+     * fixes an octaveless pitch at the default octave, and leaves a pitch that
+     * already has an octave alone.
+     */
+    get octaveIsImplicit(): boolean {
+        return this._octave === undefined;
+    }
+
+    set octaveIsImplicit(value: boolean) {
+        if (value === this.octaveIsImplicit) {
+            return;
         }
+        this._octave = value ? undefined : defaults.pitchOctave;
+    }
+
+    /**
+     * Synonym for {@link Pitch#octave}.
+     *
+     * @deprecated use `.octave`, which is always a number.
+     */
+    get implicitOctave(): number {
+        return this.octave;
     }
 
     get accidental(): Accidental|undefined {
@@ -435,17 +471,21 @@ export class Pitch extends prebase.ProtoM21Object {
     }
 
     get nameWithOctave(): string {
+        if (this.octaveIsImplicit) {
+            return this.name;
+        }
         return this.name + this.octave.toString();
     }
 
     set nameWithOctave(pn: string) {
         const storedOctave = pn.match(/\d+/);
-        if (storedOctave !== undefined) {
+        if (storedOctave) {
             pn = pn.replace(/\d+/, '');
             this.octave = parseInt(storedOctave[0]);
             this.name = pn;
         } else {
             this.name = pn;
+            this.octaveIsImplicit = true;
         }
     }
 
@@ -530,7 +570,7 @@ export class Pitch extends prebase.ProtoM21Object {
      * @readonly
      */
     get unicodeNameWithOctave() {
-        if (this.octave === undefined) {
+        if (this.octaveIsImplicit) {
             return this.unicodeName;
         } else {
             return this.unicodeName + this.octave.toString();
@@ -545,10 +585,7 @@ export class Pitch extends prebase.ProtoM21Object {
     _getEnharmonicHelper(inPlace=false, directionInt=0) {
         // differs from Python version because
         // cannot import interval here.
-        let octaveStored = true;
-        if (this.octave === undefined) {
-            octaveStored = false;
-        }
+        const octaveWasImplicit = this.octaveIsImplicit;
         const p = this.clone();
         p.diatonicNoteNum += directionInt;
         if (p.accidental === undefined) {
@@ -561,6 +598,9 @@ export class Pitch extends prebase.ProtoM21Object {
         }
 
         if (!inPlace) {
+            if (octaveWasImplicit) {
+                p.octaveIsImplicit = true;
+            }
             return p;
         }
         this.step = p.step;
@@ -568,8 +608,8 @@ export class Pitch extends prebase.ProtoM21Object {
         if (p.microtone === undefined) {
             this.microtone = p.microtone;
         }
-        if (!octaveStored) {
-            this.octave = undefined;
+        if (octaveWasImplicit) {
+            this.octaveIsImplicit = true;
         } else {
             this.octave = p.octave;
         }
@@ -620,7 +660,11 @@ export class Pitch extends prebase.ProtoM21Object {
             } else {
                 // by resetting the pitch space value, we get a simpler
                 // enharmonic spelling
+                const octaveWasImplicit = this.octaveIsImplicit;
                 returnObj.ps = this.ps;
+                if (octaveWasImplicit) {
+                    returnObj.octaveIsImplicit = true;
+                }
             }
         }
 
@@ -1237,10 +1281,8 @@ function _dissonanceScore(
                 for (let j = i + 1; j < pitches.length; j++) {
                     const p1 = pitches[i];
                     const p2 = pitches[j].clone();
-                    // music21p sets p2.octave to None here so intervals stay
-                    // simple; m21j pitches always carry an octave, so normalize
-                    // to the default (4) which is music21p's implicit octave.
-                    p2.octave = 4;
+                    // drop the octave so intervals stay simple
+                    p2.octaveIsImplicit = true;
                     intervals.push(new interval.Interval(p1, p2));
                 }
             }

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -174,6 +174,8 @@ export class AbstractScale extends Scale {
         } else {
             pitchObj = pitchObj.clone();
         }
+        // a realization must sit in some octave, even if the reference had none
+        pitchObj.octaveIsImplicit = false;
         const post: pitch.Pitch[] = [pitchObj];
         for (const intV of this._net) {
             pitchObj = intV.transposePitch(pitchObj);
@@ -187,6 +189,11 @@ export class AbstractScale extends Scale {
         _nodeName: string|number, 
         nodeDegreeTarget: number
     ): pitch.Pitch {
+        if (pitchReference.octaveIsImplicit) {
+            // degrees must climb out of the reference octave, so pin one down
+            pitchReference = pitchReference.clone();
+            pitchReference.octaveIsImplicit = false;
+        }
         const zeroIndexDegree = nodeDegreeTarget - 1;
         for (let i = 0; i < zeroIndexDegree; i++) {
             const thisIntv = this._net[i % this._net.length];

--- a/tests/moduleTests/pitch.ts
+++ b/tests/moduleTests/pitch.ts
@@ -176,6 +176,93 @@ export default function tests() {
         assert.ok(p.eq(pp));  // music21 pitch equality
     });
 
+    test('music21.pitch.Pitch.octaveIsImplicit', assert => {
+        const anyFSharp = new music21.pitch.Pitch('F#');
+        assert.ok(anyFSharp.octaveIsImplicit);
+        assert.equal(anyFSharp.octave, 4, 'implicit octave reports the default');
+        assert.equal(anyFSharp.implicitOctave, 4, 'implicitOctave is a synonym');
+        assert.equal(anyFSharp.nameWithOctave, 'F#');
+        assert.equal(anyFSharp.unicodeNameWithOctave, 'F♯');
+        assert.equal(anyFSharp.toString(), '<Pitch F#>');
+        assert.equal(anyFSharp.ps, 66);
+
+        anyFSharp.octave = 5;
+        assert.notOk(anyFSharp.octaveIsImplicit, 'setting octave makes it explicit');
+        assert.equal(anyFSharp.nameWithOctave, 'F#5');
+
+        anyFSharp.octaveIsImplicit = true;
+        assert.equal(anyFSharp.octave, 4);
+        assert.equal(anyFSharp.nameWithOctave, 'F#');
+
+        // false gives the default octave explicitly...
+        anyFSharp.octaveIsImplicit = false;
+        assert.equal(anyFSharp.nameWithOctave, 'F#4');
+        // ...but leaves a pitch that already has an octave alone
+        const gSharp5 = new music21.pitch.Pitch('G#5');
+        gSharp5.octaveIsImplicit = false;
+        assert.equal(gSharp5.octave, 5);
+
+        // creation paths
+        assert.ok(new music21.pitch.Pitch().octaveIsImplicit);
+        assert.ok(new music21.pitch.Pitch(3).octaveIsImplicit, 'pitchClass');
+        assert.notOk(new music21.pitch.Pitch(65).octaveIsImplicit, 'midi number');
+        assert.notOk(new music21.pitch.Pitch('C4').octaveIsImplicit);
+        assert.ok(new music21.note.Note('B-').pitch.octaveIsImplicit);
+        assert.equal(new music21.note.Note('B-').octave, 4);
+        assert.equal(new music21.note.Note('B-3').octave, 3);
+
+        // implicitness survives cloning, transposition, and enharmonic changes
+        const anyD = new music21.pitch.Pitch('D');
+        assert.ok(anyD.clone().octaveIsImplicit);
+        assert.ok(new music21.interval.Interval('M2').transposePitch(anyD).octaveIsImplicit);
+        assert.ok(new music21.interval.ChromaticInterval(3).transposePitch(anyD).octaveIsImplicit);
+        assert.ok(anyD.getHigherEnharmonic().octaveIsImplicit);
+        assert.notOk(
+            new music21.interval.Interval('M2')
+                .transposePitch(new music21.pitch.Pitch('D4')).octaveIsImplicit
+        );
+
+        // a P8 up from an octaveless pitch is the same octaveless pitch
+        const anyGSharp = new music21.pitch.Pitch('G#');
+        const octaveUp = new music21.interval.Interval('P8').transposePitch(anyGSharp);
+        assert.equal(octaveUp.nameWithOctave, 'G#');
+        // but an interval wider than an octave still spells correctly
+        const ninthUp = new music21.interval.Interval('M9')
+            .transposePitch(new music21.pitch.Pitch('C'));
+        assert.equal(ninthUp.name, 'D');
+
+        // an implicit octave is not the same as an explicit default octave
+        assert.notOk(new music21.pitch.Pitch('C').eq(new music21.pitch.Pitch('C4')));
+        assert.ok(new music21.pitch.Pitch('C').eq(new music21.pitch.Pitch('C')));
+
+        // nameWithOctave round-trips
+        const p = new music21.pitch.Pitch('E-2');
+        p.nameWithOctave = 'E-';
+        assert.ok(p.octaveIsImplicit);
+        assert.equal(p.nameWithOctave, 'E-');
+    });
+
+    test('music21.pitch.Pitch.octave is always a number', assert => {
+        // key signatures and scales hand out octaveless pitches, but .octave
+        // is never undefined, so display and MIDI code always has one to use.
+        const ks = new music21.key.KeySignature(3);
+        for (const p of ks.alteredPitches) {
+            assert.ok(p.octaveIsImplicit, `${p.name} is octaveless`);
+            assert.equal(typeof p.octave, 'number');
+            assert.equal(p.vexflowName(), `${p.step}#/4`);
+        }
+        assert.deepEqual(ks.alteredPitches.map(p => p.nameWithOctave), ['F#', 'C#', 'G#']);
+
+        const k = new music21.key.Key('E-');
+        assert.ok(k.tonic.octaveIsImplicit, 'a Key tonic has no octave of its own');
+        // ...yet its scale is realized in a real octave
+        assert.deepEqual(
+            namesWithOctave(k.getScale().getPitches()),
+            ['E-4', 'F4', 'G4', 'A-4', 'B-4', 'C5', 'D5', 'E-5']
+        );
+        assert.equal(k.getScale().pitchFromDegree(5).nameWithOctave, 'B-4');
+    });
+
     test('music21.pitch.Pitch.updateAccidentalDisplay', assert => {
         let p1 = new music21.pitch.Pitch('D#5');
         let p2 = new music21.pitch.Pitch('D#5');


### PR DESCRIPTION
Music21p started off with a very broad concept of implicit octaves -- simply make octave = None and tada -- it was pitch without octave.  But sometimes you need an octave, so it had `.implicitOctave` which gave `4` for octaveless pitches.

By the time I started on music21j I recognized that music21p's version was overly complicated.  So music21j only had octave as a number (int).  It never supported implicit octaves.

Now as of https://github.com/cuthbertLab/music21/pull/2023 music21p also makes octave only a number.  Here we add "octaveIsImplicit" for parity with music21p and leave our always-int `.octave` alone.

Other changes to sync w/ music21p but break older behavior here:

* new Pitch('C').nameWithOctave is now 'C', not 'C4' — same for unicodeNameWithOctave, toString() and Note.nameWithOctave.
* new Pitch('C').eq(new Pitch('C4')) is now false; eq compares the stored octave, not the reported one.
* KeySignature.alteredPitches and Key.tonic are octaveless.
* Pitch(3) (a pitchClass) is octaveless; Pitch(65) (a midi number) is not.

AI-assisted (Claude)

